### PR TITLE
Release 0.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tplyr2
 Title: A Grammar of Clinical Summary Tables
-Version: 0.1.0.9000
+Version: 0.2.0
 Authors@R:
     person("Mike", "Stackhouse", , "mike.stackhouse@atorusresearch.com", role = c("aut", "cre"))
 Description: Implements a grammar of summary data for clinical reports. Clinical

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# tplyr2 0.1.0.9000
+# tplyr2 0.2.0
 
 ## New features
 


### PR DESCRIPTION
Cuts the **0.2.0** release: finalizes the accumulated `0.1.0.9000` development changelog under a `0.2.0` heading and bumps `DESCRIPTION` `Version` to `0.2.0`.

Minor bump per semver — the cycle since the last release adds new features (not just fixes). No git tags/releases existed previously; `0.2.0` follows the conventional next-release from the `0.1.0.9000` dev version.

## Changes rolled into 0.2.0 (all already merged to `main`)

**New features**
- `stat_columns` count-layer setting — one result column per statistic per column group (#10)
- `pct_lt` / `pct_gt` — `<1` / `>99` regulatory percent display (#14)
- `zero_count_display` — `full` / `count_only` / `blank` for zero cells (#14)
- `shift_denom = "column"` — column-wise ("% within the from group") shift denominators + matching header N (#18)
- `tplyr_meta` gains a `statistic` field for `stat_columns` layers

**Bug fixes**
- Result / risk-difference columns ordered by numeric suffix (no more `res10` before `res2`)
- Count & shift `res*` columns ordered by the `cols` factor levels, consistent with `group_desc()` (#13)
- `group_desc(stats_as_columns = TRUE)` with a `by` variable preserves by-groups instead of collapsing to the last (#20)

**Documentation**
- `denoms_by` **replaces** (not augments) the default `cols` denominator grouping — `?layer_settings` + denominators vignette (#19)

## Notes
- Version-only change; no source/behavior changes in this PR. `R CMD build` produces `tplyr2_0.2.0.tar.gz` cleanly.
- Does **not** include the byfactor/nested row-ordering work (#16, PR #17) — that PR isn't merged to `main` yet, so it's intentionally excluded from this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
