### PR TITLE
Order group_desc by-group rows by factor levels (#20 follow-up)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,11 @@
   now keeps the by-groups as rows and produces one result column per
   treatment x statistic (labelled `"<arm> | <stat>"`). Behavior without a `by`
   variable (treatment groups as rows, statistics as columns) is unchanged.
+- `group_desc()` now orders its `by`-group rows by the `by` variable's factor
+  levels (then a VARN companion, then alphabetically) instead of always
+  alphabetically (#20). Previously a factor `by` such as visits came out
+  mis-ordered (e.g. `Week 12` before `Week 2`); this applies to both the
+  standard stats-as-rows output and `stats_as_columns = TRUE`.
 
 ## Documentation
 

--- a/R/build_desc.R
+++ b/R/build_desc.R
@@ -177,6 +177,20 @@ build_desc_single <- function(dt, tv, cols, by_data_vars, by_labels,
 
   long <- data.table::rbindlist(result_rows)
 
+  # Ordering key for by-group rows, respecting the by variables' factor levels
+  # (then VARN, then alphabetical). Without this, by groups fall out in the
+  # dcast's alphabetical order, e.g. "Week 12" before "Week 2" (issue #20).
+  if (length(by_data_vars) > 0) {
+    ord_codes <- map(by_data_vars, function(bv) {
+      v <- long[[bv]]
+      if (is.factor(v)) as.integer(v)
+      else compute_var_order(as.character(v), var_name = bv, data_dt = dt)
+    })
+    key_df <- stats::setNames(as.data.frame(ord_codes, stringsAsFactors = FALSE),
+                              str_c("k", seq_along(ord_codes)))
+    long[, .by_ord := data.table::frankv(key_df, ties.method = "dense")]
+  }
+
   # Build row label columns
   label_cols <- character(0)
   col_idx <- 1L
@@ -211,12 +225,15 @@ build_desc_single <- function(dt, tv, cols, by_data_vars, by_labels,
   # dcast to wide
   all_label_cols <- label_cols
   col_labels <- NULL
+  # Carry the by-group ordering key through the cast (it is constant per by
+  # group, so it never splits a dcast cell)
+  extra_lhs <- if (".by_ord" %in% names(long)) ".by_ord" else character(0)
 
   if (length(cols) == 0) {
-    wide <- long[, c(all_label_cols, "formatted", "stat_order"), with = FALSE]
+    wide <- long[, c(all_label_cols, "formatted", "stat_order", extra_lhs), with = FALSE]
     data.table::setnames(wide, "formatted", "res1")
   } else {
-    lhs <- paste(c(all_label_cols, "stat_order"), collapse = " + ")
+    lhs <- paste(c(all_label_cols, "stat_order", extra_lhs), collapse = " + ")
     rhs <- prepare_cast_column(long, cols, get_col_levels(dt, cols))
     formula_str <- paste(lhs, "~", rhs)
     wide <- data.table::dcast(
@@ -226,7 +243,7 @@ build_desc_single <- function(dt, tv, cols, by_data_vars, by_labels,
       fill = ""
     )
 
-    val_cols <- setdiff(names(wide), c(all_label_cols, "stat_order"))
+    val_cols <- setdiff(names(wide), c(all_label_cols, "stat_order", extra_lhs))
     col_labels <- build_col_labels(val_cols, col_n)
     new_names <- str_c("res", seq_along(val_cols))
     data.table::setnames(wide, val_cols, new_names)
@@ -245,6 +262,12 @@ build_desc_single <- function(dt, tv, cols, by_data_vars, by_labels,
     wide[, ord1 := stat_order]
   }
   wide[, stat_order := NULL]
+
+  # Secondary ordering: by-group factor order within each statistic
+  if (".by_ord" %in% names(wide)) {
+    wide[, ord2 := .by_ord]
+    wide[, .by_ord := NULL]
+  }
 
   # Attach label attributes to result columns
   if (!is.null(col_labels)) {
@@ -391,8 +414,15 @@ transpose_stats_with_by <- function(wide, res_cols, trt_labels, by_cols, stat_co
     stat_names <- unique(wide[[stat_col]])
   }
 
-  # One row per by-group combination, in first-appearance order
-  out <- unique(wide[, by_cols, with = FALSE])
+  # One row per by-group combination, ordered by the by-group factor order
+  # (ord2, set upstream) so e.g. "Week 2" precedes "Week 12" (issue #20).
+  if ("ord2" %in% names(wide)) {
+    out <- unique(wide[, c(by_cols, "ord2"), with = FALSE])
+    data.table::setorderv(out, "ord2")
+    out[, ord2 := NULL]
+  } else {
+    out <- unique(wide[, by_cols, with = FALSE])
+  }
   out[, .row_ord := seq_len(.N)]
 
   col_labels <- character(0)

--- a/tests/testthat/test-build_desc.R
+++ b/tests/testthat/test-build_desc.R
@@ -674,3 +674,49 @@ test_that("stats_as_columns=TRUE without by is unchanged (arm rows, stat cols)",
   expect_true(all(c("Mean", "n") %in% names(b)))
   expect_equal(nrow(b), 2)
 })
+
+# Issue #20 (follow-up): by-group rows must follow factor levels, not alphabetical
+test_that("desc orders by-group rows by factor levels", {
+  d <- data.frame(
+    TRTP = rep(c("A", "B"), each = 9),
+    VISIT = factor(rep(c("Week 2", "Week 12", "Baseline"), 6),
+                   levels = c("Baseline", "Week 2", "Week 12")),
+    AVAL = 1:18
+  )
+  # Regular (stats-as-rows) desc
+  b <- tplyr_build(tplyr_spec(cols = "TRTP", layers = tplyr_layers(
+    group_desc("AVAL", by = "VISIT", settings = layer_settings(
+      format_strings = list(Mean = f_str("xx.x", "mean")))))), d)
+  b <- b[order(b$ord_layer_1, b$ord_layer_2), ]
+  expect_equal(b$rowlabel1, c("Baseline", "Week 2", "Week 12"))
+})
+
+test_that("stats_as_columns orders by-group rows by factor levels", {
+  d <- data.frame(
+    TRTP = rep(c("A", "B"), each = 9),
+    VISIT = factor(rep(c("Week 2", "Week 12", "Baseline"), 6),
+                   levels = c("Baseline", "Week 2", "Week 12")),
+    AVAL = 1:18
+  )
+  b <- tplyr_build(tplyr_spec(cols = "TRTP", layers = tplyr_layers(
+    group_desc("AVAL", by = "VISIT", settings = layer_settings(
+      format_strings = list(Mean = f_str("xx.x", "mean"), n = f_str("xx", "n")),
+      stats_as_columns = TRUE)))), d)
+  b <- b[order(b$ord_layer_1), ]
+  expect_equal(b$rowlabel1, c("Baseline", "Week 2", "Week 12"))
+})
+
+test_that("desc by-group order respects a VARN companion column", {
+  d <- data.frame(
+    TRTP = "A",
+    AVISIT = rep(c("Week 2", "Week 12", "Baseline"), 4),
+    AVISITN = rep(c(2, 12, 0), 4),
+    AVAL = 1:12
+  )
+  b <- tplyr_build(tplyr_spec(cols = "TRTP", layers = tplyr_layers(
+    group_desc("AVAL", by = "AVISIT", settings = layer_settings(
+      format_strings = list(Mean = f_str("xx.x", "mean")))))), d)
+  b <- b[order(b$ord_layer_1, b$ord_layer_2), ]
+  # AVISITN orders Baseline(0) < Week 2(2) < Week 12(12)
+  expect_equal(b$rowlabel1, c("Baseline", "Week 2", "Week 12"))
+})


### PR DESCRIPTION
Follow-up to #20 (the original fix landed in #21). Re: https://github.com/atorus-research/tplyr2/issues/20#issuecomment-5075217040

## What was still broken

#21 stopped `stats_as_columns = TRUE` from dropping the by-groups, but the by-group **rows were still ordered alphabetically**, ignoring the `by` variable's factor levels. The simple reprex (`g1/g2/g3`) didn't reveal it because that order is alphabetical anyway. A real factor `by` — like visits — comes out mis-ordered:

```r
VISIT <- factor(c("Baseline","Week 2","Week 12"), levels = c("Baseline","Week 2","Week 12"))
# rows came out: Baseline, Week 12, Week 2   ("Week 12" < "Week 2" alphabetically)
```

That directly breaks the pilot's "visits down the stub" tables. The alphabetical ordering affected **both** the standard stats-as-rows desc output and `stats_as_columns = TRUE`.

## Fix

`build_desc_single()` now computes a by-group ordering key from the `by` variables' factor levels (falling back to a `<VAR>N` companion, then alphabetical), threads it through the `dcast`, and emits it as `ord2`. Both output shapes now order by-groups correctly:

```r
# both stats-as-rows and stats_as_columns now give: Baseline, Week 2, Week 12
```

Verified: factor levels, multi-variable `by`, `<VAR>N` companion ordering, the original #20 reprex (unchanged), and multi-target desc (no regression).

## Scope note

Count layers order their `by` rows alphabetically too (same root behavior) — left for separate work as it overlaps the target-variable ordering in #16. This PR is scoped to `group_desc`, which is what #20 covers.

## Release

These changes belong in the same 0.2.0 scope as #21. The version-bump PR (#22) isn't merged yet, so this can go in ahead of it; the NEWS bullet is added under the current heading.

996 tests pass (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
