### PR TITLE
Fix group_count by-group ordering and total/missing rows with a by variable (#24)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,11 @@
   and desc layers (or any renderer assuming `res1` is the first `cols` level)
   could get inconsistent column order. Shift layers likewise order their
   column dimension by the shift variable's factor levels.
+- `group_count()` now orders its `by`-group rows by the `by` variable's factor
+  levels (then a VARN companion, then alphabetically) instead of always
+  alphabetically (#24). Previously a factor `by` such as visits came out
+  mis-ordered (e.g. `Week 12` before `Week 2`), matching `group_shift()` and
+  `group_desc()`.
 - `group_desc(stats_as_columns = TRUE)` combined with a `by` variable no longer
   drops the by-groups and returns only the last group's statistics (#20). It
   now keeps the by-groups as rows and produces one result column per

--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,11 @@
   alphabetically (#24). Previously a factor `by` such as visits came out
   mis-ordered (e.g. `Week 12` before `Week 2`), matching `group_shift()` and
   `group_desc()`.
+- Fixed `group_count()` total/missing rows with a `by` variable (#24): each
+  by-group's `Total` (or `Missing`) row is now labelled with its by-group value
+  instead of a blank, and special rows now sort after the normal rows within
+  each group (previously e.g. `Total` was interleaved alphabetically among the
+  target values, and with a `by` variable the row label was dropped entirely).
 - `group_desc(stats_as_columns = TRUE)` combined with a `by` variable no longer
   drops the by-groups and returns only the last group's statistics (#20). It
   now keeps the by-groups as rows and produces one result column per

--- a/R/build_count.R
+++ b/R/build_count.R
@@ -189,9 +189,18 @@ build_count_layer_single <- function(dt, tv, cols, by_data_vars, by_labels,
   compute_count_sort_keys(counts, dt, cols, by_data_vars, tv, settings)
 
   # --- dcast to wide format ---
-  wide <- cast_to_wide(counts, row_labels, cols, layer_index, col_n = col_n,
-                       stat_labels = names(fmts),
+  # Preserve by-group factor ordering through the dcast (issue #24). dcast sorts
+  # its row-label LHS alphabetically, which would order by groups by their
+  # string value; compute_count_sort_keys() already computed .ord_by_* keys
+  # (respecting factor levels > VARN > alphabetical), so prepend them to the LHS
+  # (mirrors the shift layer) and drop them afterward.
+  by_order_cols <- str_subset(names(counts), "^\\.ord_by_\\d+$")
+  wide <- cast_to_wide(counts, c(by_order_cols, row_labels), cols, layer_index,
+                       col_n = col_n, stat_labels = names(fmts),
                        col_levels = get_col_levels(dt, cols))
+  for (oc in by_order_cols) {
+    if (oc %in% names(wide)) wide[, (oc) := NULL]
+  }
 
   # --- Override ord1 with computed sort keys ---
   method <- settings$order_count_method

--- a/R/build_count.R
+++ b/R/build_count.R
@@ -172,15 +172,23 @@ build_count_layer_single <- function(dt, tv, cols, by_data_vars, by_labels,
   }
 
   # --- Combine main counts + missing + missing_subjects + total ---
+  # Flag special rows so they can be ordered after the normal rows within each
+  # by-group (the dcast otherwise interleaves e.g. "Total" alphabetically among
+  # the target values). Set on the main counts first so the column survives the
+  # column-aligning subset below.
+  counts[, .is_special := 0L]
   if (!is.null(missing_row)) {
+    missing_row[, .is_special := 1L]
     missing_row <- missing_row[, names(counts), with = FALSE]
     counts <- data.table::rbindlist(list(counts, missing_row), use.names = TRUE, fill = TRUE)
   }
   if (!is.null(missing_subjects_row)) {
+    missing_subjects_row[, .is_special := 1L]
     missing_subjects_row <- missing_subjects_row[, names(counts), with = FALSE]
     counts <- data.table::rbindlist(list(counts, missing_subjects_row), use.names = TRUE, fill = TRUE)
   }
   if (!is.null(total_result)) {
+    total_result[, .is_special := 1L]
     total_result <- total_result[, names(counts), with = FALSE]
     counts <- data.table::rbindlist(list(counts, total_result), use.names = TRUE, fill = TRUE)
   }
@@ -194,11 +202,15 @@ build_count_layer_single <- function(dt, tv, cols, by_data_vars, by_labels,
   # string value; compute_count_sort_keys() already computed .ord_by_* keys
   # (respecting factor levels > VARN > alphabetical), so prepend them to the LHS
   # (mirrors the shift layer) and drop them afterward.
+  # `.is_special` sits between the by keys and the row labels so special rows
+  # (total/missing) sort after the normal rows within each by-group (#24).
   by_order_cols <- str_subset(names(counts), "^\\.ord_by_\\d+$")
-  wide <- cast_to_wide(counts, c(by_order_cols, row_labels), cols, layer_index,
-                       col_n = col_n, stat_labels = names(fmts),
+  special_col <- if (".is_special" %in% names(counts)) ".is_special" else character(0)
+  drop_cols <- c(by_order_cols, special_col)
+  wide <- cast_to_wide(counts, c(by_order_cols, special_col, row_labels), cols,
+                       layer_index, col_n = col_n, stat_labels = names(fmts),
                        col_levels = get_col_levels(dt, cols))
-  for (oc in by_order_cols) {
+  for (oc in drop_cols) {
     if (oc %in% names(wide)) wide[, (oc) := NULL]
   }
 
@@ -885,10 +897,15 @@ build_row_labels_special <- function(dt, by_labels, by_data_vars, tv, existing_l
     col_idx <- col_idx + 1L
   }
 
-  # Add by data variable columns (use empty string for special rows if not present)
+  # Add by data variable columns. Special rows (total/missing/missing_subjects)
+  # are computed per by-group, so the by variable value is present in `dt` and
+  # must label the row — otherwise every group's special row collapses to the
+  # same blank label (issue #24).
   for (bv in by_data_vars) {
     col_name <- str_c("rowlabel", col_idx)
-    if (!col_name %in% names(dt)) {
+    if (bv %in% names(dt)) {
+      dt[, (col_name) := as.character(get(bv))]
+    } else if (!col_name %in% names(dt)) {
       dt[, (col_name) := ""]
     }
     col_idx <- col_idx + 1L

--- a/R/ordering.R
+++ b/R/ordering.R
@@ -67,14 +67,21 @@ compute_count_sort_keys <- function(counts, dt, cols, by_data_vars, tv, settings
   ordering_cols_setting <- settings$ordering_cols
   result_order_var <- settings$result_order_var %||% "n"
 
-  # Sort key for each by_data_var
-
+  # Sort key for each by_data_var. The by columns on `counts` are character
+  # (rebuilt from CJ levels in complete_counts), so recover a factor by
+  # variable's level order from the source data directly; otherwise fall back
+  # to compute_var_order (VARN companion, then alphabetical). Issue #24.
   for (i in seq_along(by_data_vars)) {
     bv <- by_data_vars[i]
     col_name <- str_c(".ord_by_", i)
-    counts[, (col_name) := compute_var_order(
-      get(bv), var_name = bv, data_dt = dt
-    )]
+    if (is.factor(dt[[bv]])) {
+      lv <- levels(dt[[bv]])
+      counts[, (col_name) := match(as.character(get(bv)), lv)]
+    } else {
+      counts[, (col_name) := compute_var_order(
+        get(bv), var_name = bv, data_dt = dt
+      )]
+    }
   }
 
   # Sort key for target variable

--- a/tests/testthat/test-build_count.R
+++ b/tests/testthat/test-build_count.R
@@ -490,3 +490,44 @@ test_that("zero_count_display controls how zero cells render", {
   expect_equal(trimws(zc_count), "0")
   expect_equal(trimws(zc_blank), "")
 })
+
+# Issue #24: total/missing rows with a by variable are labelled and placed correctly
+test_that("total_row with a by variable labels each group's total and places it last", {
+  d <- data.frame(
+    TRTP = rep(c("A", "B"), each = 9),
+    VISIT = factor(rep(c("Baseline", "Week 2", "Week 12"), 6),
+                   levels = c("Baseline", "Week 2", "Week 12")),
+    RESP = rep(c("Y", "N", "Y"), 6)
+  )
+  b <- tplyr_build(tplyr_spec(cols = "TRTP", layers = tplyr_layers(
+    group_count("RESP", by = "VISIT", settings = layer_settings(total_row = TRUE)))), d)
+  b <- b[order(b$ord_layer_1), ]
+
+  # Each VISIT group has its own Total row, labelled with the VISIT value
+  total_rows <- b[b$rowlabel2 == "Total", ]
+  expect_equal(nrow(total_rows), 3)
+  expect_setequal(total_rows$rowlabel1, c("Baseline", "Week 2", "Week 12"))
+  # No blank by-labels
+  expect_false(any(b$rowlabel1 == ""))
+
+  # Within each VISIT, Total is the last row
+  for (v in c("Baseline", "Week 2", "Week 12")) {
+    grp <- b[b$rowlabel1 == v, ]
+    expect_equal(grp$rowlabel2[nrow(grp)], "Total")
+  }
+})
+
+test_that("special rows sort after normal rows (Missing before Total)", {
+  d <- data.frame(
+    TRTP = rep(c("A", "B"), each = 6),
+    RESP = c("Y", "N", "Y", NA, "Y", "N", "Y", "N", "Y", "Y", NA, "N")
+  )
+  b <- tplyr_build(tplyr_spec(cols = "TRTP", layers = tplyr_layers(
+    group_count("RESP", settings = layer_settings(
+      total_row = TRUE, missing_count = list(label = "Missing"))))), d)
+  b <- b[order(b$ord_layer_1), ]
+  # Order: category rows, then Missing, then Total
+  labs <- b$rowlabel1
+  expect_equal(labs[(length(labs) - 1):length(labs)], c("Missing", "Total"))
+  expect_true(which(labs == "Missing") < which(labs == "Total"))
+})

--- a/tests/testthat/test-ordering.R
+++ b/tests/testthat/test-ordering.R
@@ -164,3 +164,39 @@ test_that("multi-layer output has correct ord_layer_index", {
   expect_true(1 %in% result$ord_layer_index)
   expect_true(2 %in% result$ord_layer_index)
 })
+
+# Issue #24: count layers order by-group rows by the by variable's factor levels
+test_that("count orders by-group rows by factor levels", {
+  d <- data.frame(
+    TRTP = rep(c("A", "B"), each = 9),
+    VISIT = factor(rep(c("Week 2", "Week 12", "Baseline"), 6),
+                   levels = c("Baseline", "Week 2", "Week 12")),
+    RESP = rep(c("Y", "N", "Y"), 6)
+  )
+  b <- tplyr_build(tplyr_spec(cols = "TRTP", layers = tplyr_layers(
+    group_count("RESP", by = "VISIT"))), d)
+  b <- b[order(b$ord_layer_1), ]
+  expect_equal(unique(b$rowlabel1), c("Baseline", "Week 2", "Week 12"))
+})
+
+test_that("count by-group order respects a VARN companion", {
+  d <- data.frame(
+    TRTP = "A",
+    AVISIT = rep(c("Week 2", "Week 12", "Baseline"), 4),
+    AVISITN = rep(c(2, 12, 0), 4),
+    RESP = rep(c("Y", "N"), 6)
+  )
+  b <- tplyr_build(tplyr_spec(cols = "TRTP", layers = tplyr_layers(
+    group_count("RESP", by = "AVISIT"))), d)
+  b <- b[order(b$ord_layer_1), ]
+  expect_equal(unique(b$rowlabel1), c("Baseline", "Week 2", "Week 12"))
+})
+
+test_that("count by-group order falls back to alphabetical for non-factor", {
+  d <- data.frame(TRTP = "A", G = rep(c("zeta", "alpha", "mid"), 4),
+                  RESP = rep(c("Y", "N"), 6))
+  b <- tplyr_build(tplyr_spec(cols = "TRTP", layers = tplyr_layers(
+    group_count("RESP", by = "G"))), d)
+  b <- b[order(b$ord_layer_1), ]
+  expect_equal(unique(b$rowlabel1), c("alpha", "mid", "zeta"))
+})


### PR DESCRIPTION
Closes #24 (fully — both the ordering and the total-row parts).

## 1. by-group row ordering (original scope)

`group_count()` ordered its `by`-group rows alphabetically, ignoring the by variable's factor levels — the count-layer analogue of the `group_desc` by-ordering fix (#23). `group_shift()` already handled this via `.by_order_*` keys; count didn't.

```r
by = factor(VISIT, levels = c("Baseline","Week 2","Week 12"))
# was:  Baseline, Week 12, Week 2   ("Week 12" < "Week 2" alphabetically)
# now:  Baseline, Week 2,  Week 12
```

`compute_count_sort_keys()` now recovers a factor by variable's level order from the source data (then VARN, then alphabetical), and the single-variable count path prepends those keys to the `dcast` LHS (mirroring `group_shift`).

## 2. total/missing rows with a `by` variable (the secondary bug noted in #24)

With a `by` variable, `compute_total_row()` / `compute_missing_counts()` produce **one special row per by-group**, but `build_row_labels_special()` **blanked** the by variable's row label — so every group's `Total`/`Missing` collapsed to the same blank label (dropping the by value, and on `main` triggering a `dcast` duplicate-aggregation warning with wrong values). Fixed: the special-row label now carries its by-group value.

While fixing that I found special rows were also **placed alphabetically** among the target values (e.g. `Total` between `N` and `Y`) — it only *looked* correct when the target values happened to sort before `"Total"`, and it affected the no-`by` case too. A `.is_special` flag injected into the `dcast` LHS now sorts special rows **after** the normal rows within each group (Missing before Total).

```
# group_count("RESP", by = "VISIT", total_row = TRUE)
Baseline | N ;  Baseline | Y ;  Baseline | Total
Week 2   | N ;  Week 2   | Y ;  Week 2   | Total
Week 12  | N ;  Week 12  | Y ;  Week 12  | Total
```

## Scope / notes

- Single-variable count path (the reported cases). Nested count runs through `sort_nested()` and is left for separate work (relates to #16).
- Kept self-contained from #16/PR #17 — does not touch `compute_var_order()` or target-variable ordering.
- Part of the 0.2.0 scope. Adds NEWS bullets under the current heading; the version-bump PR (#22) should merge last.

996 tests pass (5 new across ordering + total-row cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
