### PR TITLE
Order count rows by target factor levels (byfactor + nested) (#16)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,12 @@
   instead of a blank, and special rows now sort after the normal rows within
   each group (previously e.g. `Total` was interleaved alphabetically among the
   target values, and with a `by` variable the row label was dropped entirely).
+- `group_count(order_count_method = "byfactor")` now orders category rows by the
+  target variable's factor levels instead of alphabetically (#16). The target
+  column is coerced to character while counts are built, so the level order is
+  now recovered from the source data (`compute_var_order()`). Nested count
+  layers likewise order their outer and inner categories by factor levels
+  (previously they fell back to the dcast's alphabetical row order).
 - `group_desc(stats_as_columns = TRUE)` combined with a `by` variable no longer
   drops the by-groups and returns only the last group's statistics (#20). It
   now keeps the by-groups as rows and produces one result column per

--- a/R/build_count.R
+++ b/R/build_count.R
@@ -361,7 +361,31 @@ build_count_layer_nested <- function(dt, target_vars, cols, by_data_vars, by_lab
   }
 
   # Sort for correct interleaving: outer value, then level, then inner value
-  sort_nested(combined, target_vars, by_data_vars)
+  sort_nested(combined, target_vars, by_data_vars, dt = dt)
+
+  # Handle missing row (outermost level only). Appended before the total row
+  # so it sorts ahead of it (matching the single-variable path); the row order
+  # below is derived from this physical append order.
+  if (!is.null(missing_count)) {
+    outer_tv <- target_vars[1]
+    group_vars <- c(cols, by_data_vars, outer_tv)
+    missing_result <- compute_missing_counts(
+      dt, combined[.nest_level == 1], cols, by_data_vars, outer_tv, group_vars,
+      get_nested_denom_group(settings$denoms_by, 1, cols), denom_dt,
+      distinct_by, missing_count
+    )
+    missing_row <- missing_result$missing_row
+
+    apply_count_formats(missing_row, fmts, pct_lt, pct_gt, zero_count_display)
+
+    build_nested_row_labels_special(missing_row, by_labels, by_data_vars,
+                                     target_vars, outer_tv, n_label_cols)
+    missing_row[, .nest_level := 0L]
+
+    shared_cols <- intersect(names(combined), names(missing_row))
+    missing_row <- missing_row[, shared_cols, with = FALSE]
+    combined <- data.table::rbindlist(list(combined, missing_row), use.names = TRUE, fill = TRUE)
+  }
 
   # Handle total row (outermost level only)
   if (total_row) {
@@ -384,28 +408,6 @@ build_count_layer_nested <- function(dt, target_vars, cols, by_data_vars, by_lab
     combined <- data.table::rbindlist(list(combined, total_result), use.names = TRUE, fill = TRUE)
   }
 
-  # Handle missing row (outermost level only)
-  if (!is.null(missing_count)) {
-    outer_tv <- target_vars[1]
-    group_vars <- c(cols, by_data_vars, outer_tv)
-    missing_result <- compute_missing_counts(
-      dt, combined[.nest_level == 1], cols, by_data_vars, outer_tv, group_vars,
-      get_nested_denom_group(settings$denoms_by, 1, cols), denom_dt,
-      distinct_by, missing_count
-    )
-    missing_row <- missing_result$missing_row
-
-    apply_count_formats(missing_row, fmts, pct_lt, pct_gt, zero_count_display)
-
-    build_nested_row_labels_special(missing_row, by_labels, by_data_vars,
-                                     target_vars, outer_tv, n_label_cols)
-    missing_row[, .nest_level := 0L]
-
-    shared_cols <- intersect(names(combined), names(missing_row))
-    missing_row <- missing_row[, shared_cols, with = FALSE]
-    combined <- data.table::rbindlist(list(combined, missing_row), use.names = TRUE, fill = TRUE)
-  }
-
   # Fill any remaining NA rowlabel columns
   for (i in seq_len(n_label_cols)) {
     col_name <- str_c("rowlabel", i)
@@ -419,9 +421,25 @@ build_count_layer_nested <- function(dt, target_vars, cols, by_data_vars, by_lab
 
   # Cast to wide
   row_label_cols <- str_c("rowlabel", seq_len(n_label_cols))
-  wide <- cast_to_wide(combined, row_label_cols, cols, layer_index, col_n = col_n,
+
+  # Preserve the factor-aware row order through the dcast, which otherwise
+  # re-sorts its row-label LHS alphabetically and discards sort_nested()'s
+  # interleaving (issue #16). Feed dcast a leading numeric LHS key (mirrors
+  # the shift layer's .row_order). The key must be CONSTANT across the cols
+  # dimension so a row group's per-cols rows still collapse into one wide row,
+  # so use each rowlabel group's first physical position: category rows in
+  # sort_nested() order, then the appended missing and total rows.
+  combined[, .row_seq := .I]
+  combined[, .nest_row_order := min(.row_seq), by = row_label_cols]
+  combined[, .row_seq := NULL]
+
+  wide <- cast_to_wide(combined, c(".nest_row_order", row_label_cols), cols,
+                       layer_index, col_n = col_n,
                        stat_labels = names(fmts),
                        col_levels = get_col_levels(dt, cols))
+  if (".nest_row_order" %in% names(wide)) {
+    wide[, .nest_row_order := NULL]
+  }
 
   # Add ord2 for nesting depth
   if (".nest_level" %in% names(combined)) {
@@ -531,22 +549,28 @@ build_nested_row_labels_special <- function(dt, by_labels, by_data_vars,
 
 #' Sort nested count data for correct interleaving
 #' @keywords internal
-sort_nested <- function(combined, target_vars, by_data_vars) {
+sort_nested <- function(combined, target_vars, by_data_vars, dt = NULL) {
   n_levels <- length(target_vars)
 
-  # Compute sort keys for each level
-  # Outer rank: alphabetical (or factor) position of outermost target var
-  outer_vals <- sort(unique(combined[[target_vars[1]]]))
-  combined[, .sort_outer := match(get(target_vars[1]), outer_vals)]
+  # Compute sort keys for each level. Coerce to character so the source factor
+  # levels (from `dt`) drive the order: the target column on `combined` is a
+  # factor re-leveled alphabetically by the nested rbindlist/CJ, so trusting
+  # its own levels would reintroduce alphabetical ordering (issue #16).
+  # Outer rank: factor levels > VARN > alphabetical of the outermost target var.
+  combined[, .sort_outer := compute_var_order(
+    as.character(get(target_vars[1])), var_name = target_vars[1], data_dt = dt
+  )]
 
   if (n_levels >= 2) {
-    # Inner rank: position within each outer group
+    # Inner rank: same priority, applied to the inner target var. A global key
+    # orders inner values consistently across outer groups; combined with the
+    # outer/nest_level sort below it interleaves correctly.
     combined[, .sort_inner := 0L]
     inner_rows <- combined[.nest_level >= 2]
     if (nrow(inner_rows) > 0) {
-      inner_rows[, .sort_inner := data.table::frank(
-        get(target_vars[2]), ties.method = "dense"
-      ), by = c(by_data_vars, target_vars[1])]
+      inner_rows[, .sort_inner := compute_var_order(
+        as.character(get(target_vars[2])), var_name = target_vars[2], data_dt = dt
+      )]
       # Update combined via join
       join_cols <- intersect(names(combined), names(inner_rows))
       join_cols <- setdiff(join_cols, ".sort_inner")

--- a/R/ordering.R
+++ b/R/ordering.R
@@ -27,8 +27,20 @@ compute_var_order <- function(values, var_name = NULL, data_dt = NULL,
     if (is.factor(values)) {
       return(match(values, levels(values)))
     }
-    if (!is.null(method) && method == "byfactor") {
-      # Explicitly requested but not a factor, fall through to alphabetical
+    # `values` is often a character vector here (the target column is rebuilt
+    # from CJ levels in complete_counts, and row-label columns are stored as
+    # character), so recover the factor levels from the source data. Without
+    # this, byfactor falls back to alphabetical ordering (issue #16), the
+    # row-ordering analogue of the column-ordering fix in issue #13.
+    if (!is.null(var_name) && !is.null(data_dt) &&
+        var_name %in% names(data_dt) && is.factor(data_dt[[var_name]])) {
+      lv <- levels(data_dt[[var_name]])
+      keys <- match(as.character(values), lv)
+      # Only use factor ordering if the values actually correspond to levels;
+      # otherwise (e.g. special rows) fall through to the remaining methods.
+      if (!all(is.na(keys))) {
+        return(keys)
+      }
     }
   }
 

--- a/man/sort_nested.Rd
+++ b/man/sort_nested.Rd
@@ -4,7 +4,7 @@
 \alias{sort_nested}
 \title{Sort nested count data for correct interleaving}
 \usage{
-sort_nested(combined, target_vars, by_data_vars)
+sort_nested(combined, target_vars, by_data_vars, dt = NULL)
 }
 \description{
 Sort nested count data for correct interleaving

--- a/tests/testthat/test-ordering.R
+++ b/tests/testthat/test-ordering.R
@@ -87,25 +87,58 @@ test_that("nested output has ord_layer_2", {
 # --- Order count method integration tests ---
 
 test_that("order_count_method = byfactor respects factor levels", {
+  # Levels are deliberately NON-alphabetical so factor order != alphabetical
+  # order (issue #16): the target column is coerced to character upstream, so
+  # the byfactor branch must recover levels from the source data.
   data <- data.frame(
     TRT = c("A", "A", "A", "B", "B", "B"),
-    VAL = factor(c("Z", "Y", "X", "Z", "Y", "X"), levels = c("X", "Y", "Z"))
+    VAL = factor(c("mid", "lo", "hi", "mid", "lo", "hi"),
+                 levels = c("lo", "mid", "hi"))
   )
-  spec <- tplyr_spec(
-    cols = "TRT",
-    layers = tplyr_layers(
-      group_count("VAL",
-        settings = layer_settings(
-          order_count_method = "byfactor"
-        )
-      )
-    )
-  )
+  spec <- tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_count("VAL", settings = layer_settings(order_count_method = "byfactor"))))
   result <- tplyr_build(spec, data)
-  # Factor levels are X, Y, Z so ord_layer_1 should be 1, 2, 3
-  expect_equal(result$ord_layer_1, c(1, 2, 3))
-  # Row order should follow factor: X, Y, Z
-  expect_equal(result$rowlabel1, c("X", "Y", "Z"))
+  result <- result[order(result$ord_layer_1), ]
+  # Row order follows factor levels lo, mid, hi (not alphabetical hi/lo/mid)
+  expect_equal(result$rowlabel1, c("lo", "mid", "hi"))
+})
+
+test_that("byfactor places special rows after factor-ordered categories", {
+  data <- data.frame(
+    TRT = rep(c("A", "B"), each = 6),
+    VAL = factor(rep(c("mid", "lo", "hi", NA, "lo", "hi"), 2),
+                 levels = c("lo", "mid", "hi"))
+  )
+  spec <- tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_count("VAL", settings = layer_settings(
+      order_count_method = "byfactor",
+      total_row = TRUE, missing_count = list(label = "Missing")))))
+  result <- tplyr_build(spec, data)
+  result <- result[order(result$ord_layer_1), ]
+  expect_equal(result$rowlabel1, c("lo", "mid", "hi", "Missing", "Total"))
+})
+
+test_that("compute_var_order recovers factor levels from data_dt for character input", {
+  dt <- data.table::data.table(
+    G = factor(c("hi", "lo", "mid"), levels = c("lo", "mid", "hi"))
+  )
+  keys <- tplyr2:::compute_var_order(c("hi", "lo", "mid"), var_name = "G",
+                                     data_dt = dt, method = "byfactor")
+  expect_equal(keys, c(3, 1, 2))
+})
+
+test_that("nested count orders outer categories by factor levels", {
+  data <- data.frame(
+    TRT = rep("A", 6),
+    SEV = factor(c("severe", "mild", "moderate", "severe", "mild", "moderate"),
+                 levels = c("severe", "mild", "moderate")),
+    PT  = c("b", "a", "c", "a", "c", "b")
+  )
+  spec <- tplyr_spec(cols = "TRT", layers = tplyr_layers(group_count(c("SEV", "PT"))))
+  result <- tplyr_build(spec, data)
+  result <- result[order(result$ord_layer_1, result$ord_layer_2), ]
+  outer <- result$rowlabel1[result$rowlabel2 == ""]
+  expect_equal(outer, c("severe", "mild", "moderate"))
 })
 
 test_that("default ordering preserves existing behavior", {


### PR DESCRIPTION
Closes #16. Fresh re-implementation on current `main` — supersedes #17, which went stale against the count code that #24/#25 rewrote.

## Still needed
#16 is unfixed on `main` even after #23/#25/#26: `order_count_method = "byfactor"` gives `65-80 | <65 | >80` (alphabetical) and nested `c("AESEV","AEDECOD")` gives `MILD | MODERATE | SEVERE`. #25 fixed the **by-variable** ordering (`.ord_by_*`); this is the **target variable** (`byfactor` override) and **nested** paths, which nothing merged touched.

## Fix
- **`compute_var_order()`**: the `byfactor`/auto branch now recovers factor levels from the source data when `values` is character (the target column is coerced to character while counts are built), mirroring how `byvarn` already consults `data_dt`. This fixes the single-variable `byfactor` override.
- **Nested (`sort_nested()`)**: ranks outer/inner categories from the *source* factor levels, and the nested builder feeds the `dcast` a leading numeric LHS key (like the shift layer's `.row_order`) so the factor order survives the cast. Missing is appended before total so special rows sort missing-then-total.

```r
# byfactor:  <65 | 65-80 | >80        (was 65-80 | <65 | >80)
# nested:    SEVERE | MILD | MODERATE (was MILD | MODERATE | SEVERE)
# nested + total/missing: SEVERE | MILD | MODERATE | Missing | Total
```

## Notes
- Composes cleanly with #24/#25's `.ord_by_*` / `.is_special` and total/missing handling — verified with the combined suite.
- Strengthened the existing `byfactor` test (its old `X/Y/Z` levels were coincidentally alphabetical, so it never caught the bug) and added nested + special-row + `compute_var_order` coverage.
- Part of 0.2.0 (per decision) — merge before the version-bump PR (#22).

1055 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
