### PR TITLE
Scope shift_denom='column' within by groups; normalize negative zero (#28, #29)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,14 @@
 
 ## Bug fixes
 
+- `group_shift(shift_denom = "column")` with a `by` variable now scopes the
+  column (from-group) denominator within each by-group instead of pooling it
+  across them (#28). A shift-by-visit table now gets per-visit percentages.
+  With a `by` variable the header `(N=)` reflects the arm total (the
+  per-column-group denominator varies by by-group, so no single header N can
+  represent it); the no-`by` behavior (from-group N in the header) is unchanged.
+- Descriptive statistics that round to negative zero now display as `0.0`
+  instead of `-0.0`, matching base R `format()` (#29).
 - Result and risk-difference columns are now ordered by their numeric suffix
   when layers are combined and when metadata is built. Previously tables
   with more than 9 result columns sorted them lexicographically

--- a/R/build_shift.R
+++ b/R/build_shift.R
@@ -66,12 +66,13 @@ build_shift_layer <- function(dt, layer, cols, layer_index, col_n = NULL, pop_dt
   # --- Compute denominators ---
   # Default denom_group: spec cols only (the treatment arm). shift_denom =
   # "column" makes the denominator column-wise: per shift column-variable
-  # group (the "from"/baseline group) within each arm. An explicit denoms_by
-  # overrides both.
+  # group (the "from"/baseline group) within each arm, scoped within each `by`
+  # group so a shift-by-visit table gets a per-visit denominator (issue #28).
+  # An explicit denoms_by overrides both.
   denom_group <- if (!is.null(denoms_by)) {
     denoms_by
   } else if (identical(shift_denom, "column")) {
-    c(cols, col_var)
+    c(cols, by_data_vars, col_var)
   } else if (length(cols) > 0) {
     cols
   } else {
@@ -79,14 +80,16 @@ build_shift_layer <- function(dt, layer, cols, layer_index, col_n = NULL, pop_dt
   }
 
   # When the denominator is broken down by the shift column variable, the
-  # header (N=) labels should reflect those per-column-group denominators
-  # rather than the arm totals (issue #18).
+  # header (N=) labels reflect those per-column-group denominators rather than
+  # the arm totals (issue #18). This is only well-defined when there is no `by`
+  # variable: with a `by` the column-group denominator varies per by-group, so
+  # no single header N can represent it and we keep the arm-level header.
   header_col_n <- col_n
 
   if (length(denom_group) > 0) {
     denoms <- denom_dt[, list(total = .N), by = denom_group]
     counts <- merge(counts, denoms, by = intersect(denom_group, names(counts)), all.x = TRUE)
-    if (col_var %in% denom_group && !is.null(col_n)) {
+    if (col_var %in% denom_group && length(by_data_vars) == 0 && !is.null(col_n)) {
       hn_vars <- intersect(all_cols, denom_group)
       header_col_n <- unique(denoms[, c(hn_vars, "total"), with = FALSE])
       data.table::setnames(header_col_n, "total", ".n")

--- a/R/f_str.R
+++ b/R/f_str.R
@@ -143,14 +143,18 @@ format_number_vec <- function(values, group, precision = NULL, lt = NULL, gt = N
 
   if (any(!na_mask)) {
     if (dec_width > 0) {
+      rounded <- tplyr_round(values[!na_mask], dec_width)
+      # Normalize negative zero to zero so a value rounding to -0 displays as
+      # "0.0", matching base R format() which drops the sign (issue #29).
+      rounded[rounded == 0] <- 0
       result[!na_mask] <- formatC(
-        tplyr_round(values[!na_mask], dec_width),
-        format = "f", digits = dec_width, width = total_width
+        rounded, format = "f", digits = dec_width, width = total_width
       )
     } else {
+      rounded <- tplyr_round(values[!na_mask], 0)
+      rounded[rounded == 0] <- 0
       result[!na_mask] <- formatC(
-        tplyr_round(values[!na_mask], 0),
-        format = "d", width = int_width
+        rounded, format = "d", width = int_width
       )
     }
   }

--- a/tests/testthat/test-build_shift.R
+++ b/tests/testthat/test-build_shift.R
@@ -376,3 +376,28 @@ test_that("shift works with a by variable and no spec columns", {
   expect_true("rowlabel1" %in% names(result))
   expect_true(any(grepl("^res\\d+$", names(result))))
 })
+
+# Issue #28: shift_denom="column" scopes the denominator within each by group
+test_that("shift_denom='column' with a by variable uses per-by-group denominators", {
+  d <- data.frame(TRT = "A",
+    VISIT = c(rep("V1", 5), rep("V2", 3)),
+    BASE  = c("N","N","N","N","H", "N","N","H"),
+    POST  = c("N","N","N","H","H", "N","H","H"))
+  b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_shift(c(row = "POST", column = "BASE"), by = "VISIT",
+      settings = layer_settings(shift_denom = "column",
+        format_strings = list(n_counts = f_str("xx (xxx%)", "n", "pct")))))), d)
+
+  res_cols <- grep("^res\\d+$", names(b), value = TRUE)
+  labs <- vapply(res_cols, function(c) attr(b[[c]], "label"), character(1))
+  n_col <- res_cols[grepl("\\| N", labs)]
+
+  # V1 Normal-baseline denom = 4 (3 stay N -> 75%); V2 = 2 (1 stays N -> 50%)
+  v1_nn <- b[[n_col]][b$rowlabel1 == "V1" & b$rowlabel2 == "N"]
+  v2_nn <- b[[n_col]][b$rowlabel1 == "V2" & b$rowlabel2 == "N"]
+  expect_equal(trimws(v1_nn), "3 ( 75%)")
+  expect_equal(trimws(v2_nn), "1 ( 50%)")
+
+  # Header falls back to the arm N (a single header can't show per-by-group N)
+  expect_false(any(grepl("\\(N=6\\)", labs)))
+})

--- a/tests/testthat/test-f_str.R
+++ b/tests/testthat/test-f_str.R
@@ -119,3 +119,22 @@ test_that("IBM rounding integrates with format_number_vec", {
   result_default <- tplyr2:::format_number_vec(c(2.5, 3.5), group)
   expect_equal(trimws(result_default), c("2", "4"))
 })
+
+# Issue #29: a value rounding to negative zero displays without the sign
+test_that("negative zero is normalized to zero in formatted output", {
+  fmt <- f_str("xx.x", "mean")
+  expect_equal(trimws(apply_formats(fmt, -0.005)), "0.0")
+  expect_equal(trimws(apply_formats(fmt, -0.04)), "0.0")   # rounds to -0.0
+  expect_equal(trimws(apply_formats(fmt, 0.0)), "0.0")
+  # integer format
+  fmt_i <- f_str("xx", "n")
+  expect_equal(trimws(apply_formats(fmt_i, -0.3)), "0")
+})
+
+test_that("group_desc mean of a tiny negative value shows 0.0 not -0.0", {
+  d <- data.frame(TRT = "A", CHG = c(-0.04, 0.02, -0.01, 0.01))  # mean = -0.005
+  b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_desc("CHG", settings = layer_settings(
+      format_strings = list(Mean = f_str("xx.x", "mean")))))), d)
+  expect_equal(trimws(b$res1[b$rowlabel1 == "Mean"]), "0.0")
+})


### PR DESCRIPTION
Two CDISC-pilot papercuts. Both confirmed real and worth fixing.

## #28 — `shift_denom = "column"` pools the denominator across `by` groups (correctness bug)

Follow-up to #18/#21. `shift_denom = "column"` set the denominator grouping to `c(cols, col_var)`, **omitting the `by` variables**, so with a `by` variable the column (from-group) denominator was pooled across all by-groups. A shift-by-visit table (the common case) got the pooled denominator:

```r
# was:  V1 Normal->Normal = 3/6 = 50%   (denom pooled to 6 = 4 + 2)
# now:  V1 Normal->Normal = 3/4 = 75% ,  V2 = 1/2 = 50%   (per-visit denom)
```

The grouping now includes `by_data_vars`, so percentages are scoped per by-group.

**Header note:** with a `by` variable the per-column-group denominator *varies by by-group*, so no single `(N=)` header can represent it — I keep the arm-level header there (consistent with `shift_denom = "total"`), while the cell percentages are correctly per-by-group. The no-`by` behavior (from-group N in the header, e.g. `N=2`/`N=8`) is unchanged. If you'd prefer a different header convention for the by case, easy to adjust.

## #29 — a stat rounding to negative zero displays as `-0.0` (papercut)

A `group_desc` stat that rounds to negative zero showed `-0.0`; base R `format()` drops the sign (`0.0`), so it was a spurious diff vs a base-R reference. `format_number_vec()` now normalizes a rounded `-0` to `0` before formatting (both decimal and integer formats).

```r
group_desc("CHG", ...)  # mean = -0.005  ->  "0.0"  (was "-0.0")
```

## Tests
1055 pass (3 new): per-by-group shift denominators + header fallback; negative-zero normalization at the `f_str` and `group_desc` levels.

## Release
Both are 0.2.0-scope pilot fixes — merge before the version-bump PR (#22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
