### PR TITLE
group_shift honors zero_count_display / pct_lt / pct_gt (#31)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,10 @@
   With a `by` variable the header `(N=)` reflects the arm total (the
   per-column-group denominator varies by by-group, so no single header N can
   represent it); the no-`by` behavior (from-group N in the header) is unchanged.
+- `group_shift()` now honors the `zero_count_display`, `pct_lt`, and `pct_gt`
+  layer settings, applying them the same way `group_count()` does (#31).
+  Previously a shift layer ignored them (e.g. a zero cell always rendered as
+  `0 (  0%)` even with `zero_count_display = "count_only"`).
 - Descriptive statistics that round to negative zero now display as `0.0`
   instead of `-0.0`, matching base R `format()` (#29).
 - Result and risk-difference columns are now ordered by their numeric suffix

--- a/R/build_shift.R
+++ b/R/build_shift.R
@@ -117,9 +117,12 @@ build_shift_layer <- function(dt, layer, cols, layer_index, col_n = NULL, pop_dt
   numeric_snapshot <- data.table::copy(counts)
 
   # --- Format ---
+  # Route through apply_count_formats() (same as group_count) so shift layers
+  # honor zero_count_display and the pct_lt/pct_gt thresholds (issue #31).
   fmt <- get_count_format(settings)
-  fmt_args <- map(fmt$vars, function(v) counts[[v]])
-  counts[, formatted := do.call(apply_formats, c(list(fmt), fmt_args))]
+  apply_count_formats(counts, list(fmt),
+                      pct_lt = settings$pct_lt, pct_gt = settings$pct_gt,
+                      zero_count_display = settings$zero_count_display %||% "full")
 
   # --- Build row labels ---
   row_label_cols <- build_shift_row_labels(counts, by_labels, by_data_vars, row_var)

--- a/tests/testthat/test-build_shift.R
+++ b/tests/testthat/test-build_shift.R
@@ -401,3 +401,47 @@ test_that("shift_denom='column' with a by variable uses per-by-group denominator
   # Header falls back to the arm N (a single header can't show per-by-group N)
   expect_false(any(grepl("\\(N=6\\)", labs)))
 })
+
+# Issue #31: shift layers honor zero_count_display (like group_count)
+test_that("group_shift honors zero_count_display", {
+  d <- data.frame(TRT = "A", BASE = c("N", "N", "H"), POST = c("N", "H", "H"))
+
+  mk <- function(mode) {
+    spec <- tplyr_spec(cols = "TRT", layers = tplyr_layers(
+      group_shift(c(row = "POST", column = "BASE"), settings = layer_settings(
+        zero_count_display = mode,
+        format_strings = list(n_counts = f_str("xx (xxx%)", "n", "pct"))))))
+    tplyr_build(spec, d)
+  }
+
+  res_of <- function(b, from, to) {
+    rc <- grep("^res\\d+$", names(b), value = TRUE)
+    labs <- vapply(rc, function(c) attr(b[[c]], "label"), character(1))
+    col <- rc[grepl(paste0("\\| ", from, " "), labs)]  # label: "A | <from> (N=n)"
+    trimws(b[[col]][b$rowlabel1 == to])
+  }
+
+  full <- mk("full")
+  count_only <- mk("count_only")
+  blank <- mk("blank")
+
+  # Cell from=H (baseline) to=N (post) is zero (the one High-baseline subject
+  # stayed High), with the arm total (3) as the default denominator.
+  expect_equal(res_of(full, "H", "N"), "0 (  0%)")
+  expect_equal(res_of(count_only, "H", "N"), "0")
+  expect_equal(res_of(blank, "H", "N"), "")
+})
+
+test_that("group_shift honors pct_lt threshold", {
+  # 1 of 254 baseline-Normal subjects -> 0.39% -> "<1"
+  d <- data.frame(TRT = "A",
+                  BASE = rep("N", 254),
+                  POST = c("H", rep("N", 253)))
+  b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_shift(c(row = "POST", column = "BASE"), settings = layer_settings(
+      pct_lt = 1,
+      format_strings = list(n_counts = f_str("xxx (xxx%)", "n", "pct")))))), d)
+  rc <- grep("^res\\d+$", names(b), value = TRUE)
+  hcol <- rc[1]
+  expect_true(any(grepl("<1", b[[hcol]])))
+})


### PR DESCRIPTION
Closes #31.

## The bug
`group_shift()` ignored `zero_count_display` — a zero cell always rendered `0 (  0%)` even with `zero_count_display = "count_only"`, while `group_count()` honored the same setting.

## Root cause & fix
The shift layer formatted its cells with a direct `apply_formats()` call, bypassing `apply_count_formats()` — the shared helper where `group_count()` applies `zero_count_display` (and the `pct_lt`/`pct_gt` thresholds). Routing shift formatting through `apply_count_formats()` makes all three settings work identically:

```r
group_shift(..., settings = layer_settings(zero_count_display = "count_only", ...))
#   zero cell:  "0"   (was "0 (  0%)")
```

`pct_lt`/`pct_gt` come along for free (same mechanism) and are also now honored by shift; `"full"` (the default) is unchanged.

## Tests
1067 pass (2 new): `zero_count_display` = full/count_only/blank on a shift zero cell, and a `pct_lt` `<1` case on a shift layer.

## Release
With #30 merged, this is the last pilot blocker for native `group_shift` lab-shift tables — 0.2.0 scope, so merge before the version-bump PR (#22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
