### PR TITLE
Add na/width/pad arguments to apply_formats() (#41)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 ## New features
 
+- `apply_formats()` gains `na`, `width`, and `pad` arguments (#41). `na` is a
+  string substituted for cells whose format-group inputs are all NA, used
+  instead of the blank-width fill (`na = ""` yields a truly empty cell, `nchar`
+  0; `na = "NE"` renders `"NE"`), letting `apply_formats()` replace hand-rolled
+  fixed-width formatters for externally row-bound statistics. `width` pads each
+  formatted token to a fixed total width (`pad = "right"`/`"left"`); when the
+  `na` substitution applies, it wins and the cell is not padded. The defaults
+  (`NULL`) preserve existing behavior.
 - New `as_display()` helper returning a display-ready frame — the `rowlabel*`,
   `res*`, and `rdiff*` columns only, with the internal `ord*` (and `row_id`)
   columns dropped, ready to hand to a table-rendering package (#36). Pass

--- a/R/f_str.R
+++ b/R/f_str.R
@@ -39,11 +39,23 @@ f_str <- function(format_string, ..., empty = NULL) {
 #'   `lt_gt_group`: values in `(gt, 100)` render as `">" gt`.
 #' @param lt_gt_group Optional integer index of the format group to which `lt`/`gt`
 #'   apply (used by count layers to target the percent statistic). NULL disables.
+#' @param na Optional string substituted for cells whose format-group inputs are
+#'   all NA, used *instead of* the default blank-width fill. `na = ""` produces a
+#'   truly empty cell (`nchar` 0); `na = "NE"` renders `"NE"`. The default `NULL`
+#'   preserves the blank-width fill. This lets `apply_formats()` replace
+#'   hand-rolled fixed-width formatters for externally row-bound statistics.
+#' @param width Optional integer total width to pad each formatted token to,
+#'   using [stringr::str_pad()]. When the `na` substitution applies to a cell,
+#'   `na` wins and that cell is *not* padded. The default `NULL` leaves tokens at
+#'   their natural format width.
+#' @param pad Side to pad on when `width` is set: `"right"` (default, trailing
+#'   spaces) or `"left"` (leading spaces).
 #'
 #' @return Character vector of formatted values
 #' @export
 apply_formats <- function(fmt, ..., precision = NULL, lt = NULL, gt = NULL,
-                          lt_gt_group = NULL) {
+                          lt_gt_group = NULL, na = NULL, width = NULL,
+                          pad = c("right", "left")) {
   if (is.character(fmt)) {
     # Parse on the fly for standalone use
     fmt <- f_str(fmt, ...)
@@ -91,6 +103,18 @@ apply_formats <- function(fmt, ..., precision = NULL, lt = NULL, gt = NULL,
     if (".overall" %in% names(fmt$empty)) {
       result[all_na] <- fmt$empty[[".overall"]]
     }
+  }
+
+  # Optional fixed total-width padding of the whole token
+  if (!is.null(width)) {
+    result <- str_pad(result, width = width, side = match.arg(pad))
+  }
+
+  # NA substitution: rows whose format-group inputs are all NA render as `na`.
+  # Applied last so it wins over both the blank-width fill and width padding.
+  if (!is.null(na)) {
+    all_na <- Reduce(`&`, map(args, is.na))
+    result[all_na] <- na
   }
 
   result

--- a/man/apply_formats.Rd
+++ b/man/apply_formats.Rd
@@ -10,7 +10,10 @@ apply_formats(
   precision = NULL,
   lt = NULL,
   gt = NULL,
-  lt_gt_group = NULL
+  lt_gt_group = NULL,
+  na = NULL,
+  width = NULL,
+  pad = c("right", "left")
 )
 }
 \arguments{
@@ -28,6 +31,20 @@ apply_formats(
 
 \item{lt_gt_group}{Optional integer index of the format group to which \code{lt}/\code{gt}
 apply (used by count layers to target the percent statistic). NULL disables.}
+
+\item{na}{Optional string substituted for cells whose format-group inputs are
+all NA, used \emph{instead of} the default blank-width fill. \code{na = ""} produces a
+truly empty cell (\code{nchar} 0); \code{na = "NE"} renders \code{"NE"}. The default \code{NULL}
+preserves the blank-width fill. This lets \code{apply_formats()} replace
+hand-rolled fixed-width formatters for externally row-bound statistics.}
+
+\item{width}{Optional integer total width to pad each formatted token to,
+using \code{\link[stringr:str_pad]{stringr::str_pad()}}. When the \code{na} substitution applies to a cell,
+\code{na} wins and that cell is \emph{not} padded. The default \code{NULL} leaves tokens at
+their natural format width.}
+
+\item{pad}{Side to pad on when \code{width} is set: \code{"right"} (default, trailing
+spaces) or \code{"left"} (leading spaces).}
 }
 \value{
 Character vector of formatted values

--- a/tests/testthat/test-f_str.R
+++ b/tests/testthat/test-f_str.R
@@ -50,6 +50,56 @@ test_that("apply_formats handles NA values", {
   expect_match(result[2], "^\\s+$")
 })
 
+test_that("apply_formats na= renders NA as an empty string", {
+  # na = "" -> truly empty cell (nchar 0), not blank-width fill
+  res <- apply_formats(f_str("xx.x", "x"), NA_real_, na = "")
+  expect_identical(res, "")
+  expect_equal(nchar(res), 0L)
+})
+
+test_that("apply_formats na= substitutes only all-NA cells in a vector", {
+  res <- apply_formats(f_str("xx.x", "x"), c(2.3, NA, 12.7), na = "")
+  expect_identical(res, c(" 2.3", "", "12.7"))
+})
+
+test_that("apply_formats na= accepts a non-empty replacement string", {
+  res <- apply_formats(f_str("xx.x", "x"), c(NA_real_, 2.3), na = "NE")
+  expect_identical(res, c("NE", " 2.3"))
+})
+
+test_that("apply_formats width= pads the token to a fixed total width", {
+  res <- apply_formats(f_str("xxxx.xxxx", "x"), 2.3291, width = 12)
+  expect_identical(res, "   2.3291   ")
+  expect_equal(nchar(res), 12L)
+})
+
+test_that("apply_formats width= respects pad side", {
+  res <- apply_formats(f_str("xxxx.xxxx", "x"), 2.3291, width = 12, pad = "left")
+  expect_identical(res, "      2.3291")
+  expect_equal(nchar(res), 12L)
+})
+
+test_that("apply_formats na= wins over width= (empty cell is not padded)", {
+  res <- apply_formats(f_str("xx.x", "x"), NA_real_, na = "", width = 12)
+  expect_identical(res, "")
+  expect_equal(nchar(res), 0L)
+})
+
+test_that("apply_formats na= only fires when all format-group inputs are NA", {
+  fmt <- f_str("xx (xx.x%)", "n", "pct")
+  res <- apply_formats(fmt, c(NA_real_, 5), c(NA_real_, 50), na = "")
+  expect_identical(res[1], "")            # both inputs NA -> na
+  expect_identical(res[2], " 5 (50.0%)") # neither NA -> formatted normally
+})
+
+test_that("apply_formats NULL na/width defaults preserve blank-width behavior", {
+  fmt <- f_str("xx.xx", "sd")
+  expect_identical(
+    apply_formats(fmt, c(8.59, NA_real_)),
+    apply_formats(fmt, c(8.59, NA_real_), na = NULL, width = NULL)
+  )
+})
+
 test_that("format_number_vec handles zero decimal width", {
   group <- list(int = list(width = 3L, auto = FALSE, offset = 0L, hug = FALSE),
                 dec = list(width = 0L, auto = FALSE, offset = 0L, hug = FALSE),


### PR DESCRIPTION
Closes #41

## Summary

Adds three arguments to the exported `apply_formats()` so it can replace hand-rolled fixed-width formatters for externally row-bound statistics (model p-values, LS-means, CIs).

- **`na = NULL` (primary).** A string substituted for cells whose format-group inputs are all NA, applied *instead of* the blank-width space fill. `na = ""` produces a truly empty cell (`nchar` 0); `na = "NE"` renders `"NE"`. The default `NULL` preserves the current blank-width behavior.
- **`width = NULL`, `pad = c("right", "left")` (secondary).** Pads each formatted token to a fixed total width via `stringr::str_pad()`. When the `na` substitution applies to a cell, `na` wins and that cell is *not* padded.

The `na`/`width` handling is applied in `apply_formats()` after the result string is assembled, leaving `format_number_vec()` untouched. All internal callers pass neither argument, so behavior is unchanged.

## Verified reprex outputs

- `apply_formats(f_str("xx.x","x"), NA_real_, na = "")` -> `""` (nchar 0)
- `apply_formats(f_str("xx.x","x"), c(2.3, NA, 12.7), na = "")` -> `" 2.3"`, `""`, `"12.7"`
- `apply_formats(f_str("xxxx.xxxx","x"), 2.3291, width = 12)` -> `"   2.3291   "` (nchar 12)
- `apply_formats(f_str("xx.x","x"), NA_real_, na = "", width = 12)` -> `""` (na wins)

## Testing

- Added tests in `tests/testthat/test-f_str.R` covering the four reprex cases, `pad = "left"`, multi-var partial-NA behavior, and NULL-default backward compatibility.
- `devtools::test()`: all 1119 tests pass.
- `R CMD build . --no-build-vignettes --no-manual`: clean, no Rd warnings.
- NEWS.md bullet added under `# tplyr2 0.2.0`; DESCRIPTION Version unchanged (0.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)