### PR TITLE
Support assoc_test() on group_desc layers (omnibus continuous-variable p-values) (#51)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -116,6 +116,18 @@
 
 ## Bug fixes
 
+- Omnibus `assoc_test()` no longer lets `total_group()` / `custom_group()`
+  duplicate rows leak into the `fn`'s `.data` (#53). Those rows are a display
+  construct for the count columns; including them double-counted every subject
+  and silently returned a wrong p-value (no error, no warning). The synthetic
+  rows — and their now-unused factor levels (e.g. a phantom `"Total"` level that
+  made `chisq.test()` return `NaN`) — are dropped before `fn` runs, so it sees
+  only the real observations.
+- Omnibus `assoc_test()` now places its p-value on the layer's **first display
+  row**, not the arbitrary pre-sort (dcast) row (#54). The value was written
+  before the `ord*` reorder (e.g. `order_count_method = "byfactor"`), so it could
+  strand on the wrong category (landing on `65-80` instead of `<65`, etc.);
+  placement is now derived from the ordering columns, per by-group.
 - `group_count()` `missing_count` now always emits the Missing row when set,
   zero-filling every column/by group that has no missing values, so the row
   reads `0 ( 0%)` throughout instead of being dropped (when the total missing

--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,17 @@
   2x2 denominator is taken from `pop_data` (subjects at risk), so a sparse or
   empty **reference** arm still yields a valid `0`-vs-`k` test on every row
   instead of blanking the column.
+- `assoc_test()` now works on **`group_desc`** layers in omnibus mode (#51),
+  giving a continuous-variable comparison across arms — ANOVA, Kruskal-Wallis,
+  a t-test — a native home. Same contract as count/shift: `fn` receives the
+  by-group's raw source subset (all `cols` levels) and returns a scalar p
+  (formatted by `format`) or a verbatim character string (#47), placed on the
+  by-group's first statistic row (`NA` → blank). A demographics table can now
+  produce its comparison p-values — continuous *and* categorical characteristics
+  sharing one `pval` column — entirely through tplyr2 instead of a hand-rolled
+  `aov`/`kruskal.test` side pipeline. Pairwise/per-level mode remains count-layer
+  only; supplying `comparisons` on a desc layer is now a clear error rather than
+  silently ignored.
 - New `shift_denom` setting for shift layers (#18). `shift_denom = "column"`
   computes percentages column-wise — out of each shift column group (the
   "from"/baseline group) within the treatment arm — the standard

--- a/R/assoc_test.R
+++ b/R/assoc_test.R
@@ -220,6 +220,23 @@ format_assoc_return <- function(raw, format) {
 #'   empty, a single-row table with only \code{.assoc_p}.
 #' @keywords internal
 compute_assoc_test <- function(source_dt, by_data_vars, config) {
+  # total_group()/custom_group() duplicate rows are a display construct for the
+  # count columns; they must not enter a statistical test or they double-count
+  # every subject and silently return a wrong p-value (#53). Drop them (and the
+  # internal marker) so `fn` sees only the real observations.
+  if (".tplyr_synthetic" %in% names(source_dt)) {
+    keep <- setdiff(names(source_dt), ".tplyr_synthetic")
+    source_dt <- source_dt[.tplyr_synthetic %in% c(FALSE, NA), keep, with = FALSE]
+    # Assigning the total/custom label to a factor column left its level behind;
+    # after dropping the synthetic rows those levels are globally unused, so drop
+    # them or a test that tabulates on the factor sees a phantom all-zero level
+    # (a chi-square then returns NaN) (#53).
+    fct_cols <- names(source_dt)[map_lgl(source_dt, is.factor)]
+    for (fc in fct_cols) {
+      data.table::set(source_dt, j = fc, value = droplevels(source_dt[[fc]]))
+    }
+  }
+
   run_one <- function(sub) {
     raw <- tryCatch(config$fn(as.data.frame(sub)), error = function(e) NA_real_)
     format_assoc_return(raw, config$format)
@@ -251,20 +268,34 @@ compute_assoc_test <- function(source_dt, by_data_vars, config) {
 merge_assoc_column <- function(wide, assoc, by_rl_cols, by_data_vars, config) {
   wide[, pval1 := ""]
 
+  # The omnibus value belongs on the first row of the layer's FINAL display
+  # order, but merge runs before the top-level sort by the ord* columns. Placing
+  # it on the current (dcast) first row would strand it on an arbitrary category
+  # once the rows are reordered (e.g. order_count_method = "byfactor"), so derive
+  # the display order here from the ord* columns (#54).
+  ord_cols <- sort_by_numeric_suffix(str_subset(names(wide), "^ord\\d+$"))
+  disp_rank <- if (length(ord_cols) > 0 && nrow(wide) > 0) {
+    do.call(order, lapply(ord_cols, function(oc) wide[[oc]]))
+  } else {
+    seq_len(nrow(wide))
+  }
+
   if (length(by_rl_cols) > 0) {
     # Key each wide row by its by-group (trimmed rowlabel values) and match to
-    # the computed results; place the value on the first row of each group.
+    # the computed results; place the value on the first row of each group in
+    # display order.
     wide_key <- do.call(paste, c(lapply(by_rl_cols, function(c) trimws(wide[[c]])),
                                  sep = "\r"))
     assoc_key <- do.call(paste, c(lapply(by_data_vars, function(c) trimws(assoc[[c]])),
                                   sep = "\r"))
     lookup <- setNames(assoc$.assoc_p, assoc_key)
-    first <- !duplicated(wide_key)
-    wide[first, pval1 := lookup[wide_key[first]]]
+    # First appearance of each by-group key when rows are walked in display order
+    first_in_disp <- disp_rank[!duplicated(wide_key[disp_rank])]
+    wide[first_in_disp, pval1 := lookup[wide_key[first_in_disp]]]
     wide[is.na(pval1), pval1 := ""]
   } else {
-    # No by variable: a single result on the first row
-    if (nrow(wide) > 0) wide[1L, pval1 := assoc$.assoc_p[1]]
+    # No by variable: a single result on the first row in display order
+    if (nrow(wide) > 0) wide[disp_rank[1], pval1 := assoc$.assoc_p[1]]
   }
 
   data.table::setattr(wide[["pval1"]], "label", config$label)

--- a/R/assoc_test.R
+++ b/R/assoc_test.R
@@ -1,8 +1,8 @@
-#' Association-test column(s) for count and shift layers
+#' Association-test column(s) for count, shift, and desc layers
 #'
 #' Configures an association test and lands its formatted result beside the
-#' n(\%) block. Two modes are supported, selected by whether \code{comparisons}
-#' is supplied:
+#' n(\%) (or statistic) block. Two modes are supported, selected by whether
+#' \code{comparisons} is supplied:
 #'
 #' \strong{Omnibus mode} (\code{comparisons = NULL}, the default). Runs
 #' \code{fn} once per \code{by} group, \emph{across} the treatment columns, and
@@ -12,7 +12,12 @@
 #' (e.g. \code{fisher.test(table(.data$TRT, .data$RESP))} or
 #' \code{coin::cmh_test(...)}). When the layer has no \code{by} variable the
 #' test runs once over the whole layer; otherwise once per \code{by} group, with
-#' the value placed on that group's first output row.
+#' the value placed on that group's first output row. This mode works on
+#' \strong{count}, \strong{shift}, and \strong{desc} layers -- on a desc layer
+#' it is the natural home for a continuous-variable comparison across arms
+#' (ANOVA / Kruskal-Wallis / t-test), e.g.
+#' \code{fn = function(.data) anova(lm(AGE ~ TRT, .data))[["Pr(>F)"]][1]}, with
+#' one p-value per \code{by} group on that group's first statistic row.
 #'
 #' \strong{Pairwise / per-level mode} (\code{comparisons} non-\code{NULL}).
 #' Count layers only. Emits one \code{pval} column per comparison, each
@@ -81,6 +86,12 @@
 #'   fn = function(m) fisher.test(m)$p.value,
 #'   reference = "Placebo",
 #'   comparisons = c("Low", "High"),
+#'   format = f_str("x.xxx", "p")
+#' )
+#'
+#' # Omnibus on a desc layer: continuous comparison across arms (ANOVA)
+#' at3 <- assoc_test(
+#'   fn = function(.data) anova(lm(AGE ~ TRT, .data))[["Pr(>F)"]][1],
 #'   format = f_str("x.xxx", "p")
 #' )
 #' @export

--- a/R/build.R
+++ b/R/build.R
@@ -261,6 +261,12 @@ apply_total_groups <- function(dt, total_groups) {
     total_rows <- data.table::copy(dt)
     total_rows[, (col_var) := label]
 
+    # Mark the duplicates so a statistical test (assoc_test) can exclude them —
+    # they are a display construct for the count columns and would otherwise
+    # double-count every subject (#53). Originals default to FALSE.
+    if (!".tplyr_synthetic" %in% names(dt)) dt[, .tplyr_synthetic := FALSE]
+    total_rows[, .tplyr_synthetic := TRUE]
+
     dt <- data.table::rbindlist(list(dt, total_rows), use.names = TRUE, fill = TRUE)
   }
 
@@ -287,6 +293,10 @@ apply_custom_groups <- function(dt, custom_groups) {
       if (nrow(matching) > 0) {
         group_rows <- data.table::copy(matching)
         group_rows[, (col_var) := group_name]
+        # Mark the duplicates so assoc_test can exclude them (see
+        # apply_total_groups); originals default to FALSE.
+        if (!".tplyr_synthetic" %in% names(dt)) dt[, .tplyr_synthetic := FALSE]
+        group_rows[, .tplyr_synthetic := TRUE]
         dt <- data.table::rbindlist(list(dt, group_rows), use.names = TRUE, fill = TRUE)
       }
     }

--- a/R/build_desc.R
+++ b/R/build_desc.R
@@ -41,6 +41,20 @@ build_desc_layer <- function(dt, layer, cols, layer_index, col_n = NULL, pop_dt 
     result <- transpose_stats_to_columns(result)
   }
 
+  # --- Omnibus association-test p-value column (#51) ---
+  # Desc layers support the omnibus contract only: `fn` runs once per by-group
+  # over that group's raw source-data subset (all `cols` levels) and its scalar
+  # (or verbatim character) result lands on the group's first output row; NA
+  # renders a blank. This is the same contract used by count/shift omnibus mode
+  # and is what a continuous-variable comparison (ANOVA / Kruskal / t-test)
+  # needs. Pairwise/per-level mode is count-layer only (rejected in validation).
+  if (!is.null(settings$assoc_test) && !isTRUE(settings$assoc_test$pairwise)) {
+    assoc <- compute_assoc_test(dt, by_data_vars, settings$assoc_test)
+    by_rl_cols <- str_c("rowlabel", length(by_labels) + seq_along(by_data_vars))
+    merge_assoc_column(result, assoc, by_rl_cols, by_data_vars,
+                       settings$assoc_test)
+  }
+
   result
 }
 

--- a/R/layer_settings.R
+++ b/R/layer_settings.R
@@ -40,7 +40,7 @@
 #' | `risk_diff` | X | | | |
 #' | `ci_method` | X | | | |
 #' | `ci_level` | X | | | |
-#' | `assoc_test` | X | | X | |
+#' | `assoc_test` | X | X | X | |
 #' | `pct_lt` | X | | | |
 #' | `pct_gt` | X | | | |
 #' | `zero_count_display` | X | | | |
@@ -109,8 +109,10 @@
 #'   \code{"agresti_coull"}, or \code{"jeffreys"}. See \code{\link{proportion_ci}}.
 #' @param ci_level Numeric coverage probability for the single-proportion
 #'   confidence interval keywords. Defaults to \code{0.95}.
-#' @param assoc_test A \code{\link{assoc_test}} object attaching an omnibus
-#'   association-test p-value column (count and shift layers).
+#' @param assoc_test A \code{\link{assoc_test}} object attaching an
+#'   association-test p-value column. Omnibus mode works on count, shift, and
+#'   desc layers (a desc layer's continuous comparison, e.g. ANOVA/Kruskal);
+#'   pairwise/per-level mode is count layers only.
 #' @param pct_lt Numeric less-than threshold for count-layer percents. A cell
 #'   with a nonzero count whose percent would display below this value renders
 #'   the percent as \code{"<"} followed by the threshold (e.g. \code{pct_lt = 1}

--- a/R/tplyr2-package.R
+++ b/R/tplyr2-package.R
@@ -9,7 +9,7 @@ NULL
 utils::globalVariables(c(
   ".", ".col_combo", ".comp_idx", ".disp", ".idx", ".join_key", ".missing_sort",
   ".nest_level", ".ord_tv", ".row_order", ".sort_inner", ".sort_key",
-  ".sort_outer", ".total_sort", ".var_name",
+  ".sort_outer", ".total_sort", ".tplyr_synthetic", ".var_name",
   "analysis_id", "distinct_n", "distinct_pct", "distinct_total",
   "formatted", "formatted_rd", "i..sort_inner", "i.formatted_rd",
   "id", "max_dec", "max_int", "median", "n", "og_row", "ord1",

--- a/R/validate.R
+++ b/R/validate.R
@@ -160,6 +160,14 @@ validate_layer <- function(layer, index, cols = NULL) {
   # reference is supplied explicitly, it should differ from the comparisons.
   at <- layer$settings$assoc_test
   if (inherits(at, "tplyr_assoc_test") && isTRUE(at$pairwise)) {
+    # Pairwise/per-level mode builds a per-target-level 2x2, which only a count
+    # layer has. Desc (and other non-count) layers support omnibus mode only.
+    if (!inherits(layer, "tplyr_count_layer")) {
+      stop(str_glue("Layer {index}: pairwise assoc_test (comparisons = ...) is ",
+                    "only supported on count layers; use omnibus mode ",
+                    "(no comparisons) on a {layer$layer_type} layer"),
+           call. = FALSE)
+    }
     if (!is.null(cols) && length(cols) == 0) {
       stop(str_glue("Layer {index}: pairwise assoc_test (comparisons = ...) ",
                     "requires at least one column variable (cols)"),

--- a/man/assoc_test.Rd
+++ b/man/assoc_test.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/assoc_test.R
 \name{assoc_test}
 \alias{assoc_test}
-\title{Association-test column(s) for count and shift layers}
+\title{Association-test column(s) for count, shift, and desc layers}
 \usage{
 assoc_test(
   fn,
@@ -56,8 +56,8 @@ A \code{tplyr_assoc_test} object.
 }
 \description{
 Configures an association test and lands its formatted result beside the
-n(\\%) block. Two modes are supported, selected by whether \code{comparisons}
-is supplied:
+n(\\%) (or statistic) block. Two modes are supported, selected by whether
+\code{comparisons} is supplied:
 }
 \details{
 \strong{Omnibus mode} (\code{comparisons = NULL}, the default). Runs
@@ -68,7 +68,12 @@ and all target/row levels), so a caller can tabulate and test naturally
 (e.g. \code{fisher.test(table(.data$TRT, .data$RESP))} or
 \code{coin::cmh_test(...)}). When the layer has no \code{by} variable the
 test runs once over the whole layer; otherwise once per \code{by} group, with
-the value placed on that group's first output row.
+the value placed on that group's first output row. This mode works on
+\strong{count}, \strong{shift}, and \strong{desc} layers -- on a desc layer
+it is the natural home for a continuous-variable comparison across arms
+(ANOVA / Kruskal-Wallis / t-test), e.g.
+\code{fn = function(.data) anova(lm(AGE ~ TRT, .data))[["Pr(>F)"]][1]}, with
+one p-value per \code{by} group on that group's first statistic row.
 
 \strong{Pairwise / per-level mode} (\code{comparisons} non-\code{NULL}).
 Count layers only. Emits one \code{pval} column per comparison, each
@@ -104,6 +109,12 @@ at2 <- assoc_test(
   fn = function(m) fisher.test(m)$p.value,
   reference = "Placebo",
   comparisons = c("Low", "High"),
+  format = f_str("x.xxx", "p")
+)
+
+# Omnibus on a desc layer: continuous comparison across arms (ANOVA)
+at3 <- assoc_test(
+  fn = function(.data) anova(lm(AGE ~ TRT, .data))[["Pr(>F)"]][1],
   format = f_str("x.xxx", "p")
 )
 }

--- a/man/layer_settings.Rd
+++ b/man/layer_settings.Rd
@@ -134,8 +134,10 @@ keywords. One of \code{"clopper_pearson"} (default, exact / SAS
 \item{ci_level}{Numeric coverage probability for the single-proportion
 confidence interval keywords. Defaults to \code{0.95}.}
 
-\item{assoc_test}{A \code{\link{assoc_test}} object attaching an omnibus
-association-test p-value column (count and shift layers).}
+\item{assoc_test}{A \code{\link{assoc_test}} object attaching an
+association-test p-value column. Omnibus mode works on count, shift, and
+desc layers (a desc layer's continuous comparison, e.g. ANOVA/Kruskal);
+pairwise/per-level mode is count layers only.}
 
 \item{pct_lt}{Numeric less-than threshold for count-layer percents. A cell
 with a nonzero count whose percent would display below this value renders
@@ -197,7 +199,7 @@ settings are applicable for each of the four layer types:\tabular{lllll}{
    \code{risk_diff} \tab X \tab  \tab  \tab  \cr
    \code{ci_method} \tab X \tab  \tab  \tab  \cr
    \code{ci_level} \tab X \tab  \tab  \tab  \cr
-   \code{assoc_test} \tab X \tab  \tab X \tab  \cr
+   \code{assoc_test} \tab X \tab X \tab X \tab  \cr
    \code{pct_lt} \tab X \tab  \tab  \tab  \cr
    \code{pct_gt} \tab X \tab  \tab  \tab  \cr
    \code{zero_count_display} \tab X \tab  \tab  \tab  \cr

--- a/tests/testthat/test-assoc_test.R
+++ b/tests/testthat/test-assoc_test.R
@@ -675,3 +675,121 @@ test_that("pairwise assoc_test survives JSON serialization", {
   expect_equal(s$label, c("P vs L", "P vs H"))
   expect_true(is.function(s$fn))
 })
+
+# --- desc layer (omnibus only, #51) ---
+
+.desc_assoc_data <- function() {
+  set.seed(1)
+  data.frame(
+    TRT = factor(rep(c("Placebo", "Low", "High"), each = 20),
+                 levels = c("Placebo", "Low", "High")),
+    AGE = c(rnorm(20, 75, 8), rnorm(20, 74, 8), rnorm(20, 76, 8)),
+    SEX = sample(c("M", "F"), 60, replace = TRUE),
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("desc assoc_test places one omnibus p-value on the first stat row (#51)", {
+  d <- .desc_assoc_data()
+  aov_fn <- function(.data) anova(lm(AGE ~ TRT, .data))[["Pr(>F)"]][1]
+  at <- assoc_test(fn = aov_fn, format = f_str("x.xxx", "p"), label = "ANOVA p")
+  b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_desc("AGE", settings = layer_settings(
+      format_strings = list(Mean = f_str("xx.x", "mean"), SD = f_str("xx.xx", "sd")),
+      assoc_test = at)))), d)
+
+  expect_true("pval1" %in% names(b))
+  expect_equal(attr(b$pval1, "label"), "ANOVA p")
+  disp <- as.data.frame(as_display(b))
+  # value on the first (Mean) row, blank on the rest
+  expect_equal(sum(trimws(disp$pval1) != ""), 1L)
+  expect_true(trimws(disp$pval1[disp$rowlabel1 == "Mean"]) != "")
+  expect_equal(trimws(disp$pval1[disp$rowlabel1 == "SD"]), "")
+  # matches a direct ANOVA on the whole layer
+  expected <- anova(lm(AGE ~ TRT, d))[["Pr(>F)"]][1]
+  expect_equal(trimws(disp$pval1[disp$rowlabel1 == "Mean"]),
+               trimws(apply_formats(f_str("x.xxx", "p"), expected)))
+})
+
+test_that("desc assoc_test emits one p-value per by-group (#51)", {
+  d <- .desc_assoc_data()
+  # long demographics-style frame: two continuous characteristics stacked
+  d2 <- rbind(
+    data.frame(TRT = d$TRT, VAL = d$AGE, CHAR = "Age"),
+    data.frame(TRT = d$TRT, VAL = rnorm(60, 25, 4), CHAR = "BMI")
+  )
+  at <- assoc_test(fn = function(.data) anova(lm(VAL ~ TRT, .data))[["Pr(>F)"]][1],
+                   format = f_str("x.xxx", "p"))
+  b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_desc("VAL", by = "CHAR", settings = layer_settings(
+      format_strings = list(Mean = f_str("xx.x", "mean"), SD = f_str("xx.xx", "sd")),
+      assoc_test = at)))), d2)
+  disp <- as.data.frame(as_display(b))
+
+  # one non-blank p-value per characteristic, on that group's first row
+  age <- disp[disp$rowlabel1 == "Age", ]
+  bmi <- disp[disp$rowlabel1 == "BMI", ]
+  expect_equal(sum(trimws(age$pval1) != ""), 1L)
+  expect_equal(sum(trimws(bmi$pval1) != ""), 1L)
+  expect_true(trimws(age$pval1[1]) != "")
+  # each group's value matches its own ANOVA
+  exp_age <- anova(lm(VAL ~ TRT, d2[d2$CHAR == "Age", ]))[["Pr(>F)"]][1]
+  expect_equal(trimws(age$pval1[trimws(age$pval1) != ""]),
+               trimws(apply_formats(f_str("x.xxx", "p"), exp_age)))
+})
+
+test_that("desc assoc_test passes a character fn return through verbatim (#51)", {
+  d <- .desc_assoc_data()
+  at <- assoc_test(
+    fn = function(.data) {
+      p <- anova(lm(AGE ~ TRT, .data))[["Pr(>F)"]][1]
+      if (p < 0.05) sprintf("%.3f*", p) else sprintf("%.3f ", p)
+    },
+    format = f_str("x.xxx", "p"))
+  b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_desc("AGE", settings = layer_settings(
+      format_strings = list(Mean = f_str("xx.x", "mean")),
+      assoc_test = at)))), d)
+  val <- b$pval1[trimws(b$pval1) != ""][1]
+  expect_true(grepl("\\*$", val) || grepl("\\d $", val))
+})
+
+test_that("desc assoc_test renders NA as blank (#51)", {
+  d <- .desc_assoc_data()
+  at <- assoc_test(fn = function(.data) NA_real_)
+  b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_desc("AGE", settings = layer_settings(
+      format_strings = list(Mean = f_str("xx.x", "mean")),
+      assoc_test = at)))), d)
+  expect_true(all(trimws(b$pval1) == ""))
+})
+
+test_that("pairwise assoc_test is rejected on a desc layer (#51)", {
+  d <- .desc_assoc_data()
+  at <- assoc_test(fn = function(m) 1, reference = "Placebo",
+                   comparisons = c("Low", "High"))
+  expect_error(
+    tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+      group_desc("AGE", settings = layer_settings(assoc_test = at)))), d),
+    "only supported on count layers"
+  )
+})
+
+test_that("count and desc assoc p-values share one pval column in a spec (#51)", {
+  d <- .desc_assoc_data()
+  count_at <- assoc_test(
+    fn = function(.data) chisq.test(table(.data$TRT, .data$SEX))$p.value,
+    format = f_str("x.xxx", "p"))
+  desc_at <- assoc_test(
+    fn = function(.data) anova(lm(AGE ~ TRT, .data))[["Pr(>F)"]][1],
+    format = f_str("x.xxx", "p"))
+  b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_desc("AGE", settings = layer_settings(
+      format_strings = list(Mean = f_str("xx.x", "mean")), assoc_test = desc_at)),
+    group_count("SEX", settings = layer_settings(
+      format_strings = list(n_counts = f_str("xx", "n")), assoc_test = count_at)))), d)
+
+  expect_true("pval1" %in% names(b))
+  # both layers contribute a value into the shared column
+  expect_gte(sum(trimws(b$pval1) != ""), 2L)
+})

--- a/tests/testthat/test-assoc_test.R
+++ b/tests/testthat/test-assoc_test.R
@@ -793,3 +793,105 @@ test_that("count and desc assoc p-values share one pval column in a spec (#51)",
   # both layers contribute a value into the shared column
   expect_gte(sum(trimws(b$pval1) != ""), 2L)
 })
+
+# --- #53: total_group / custom_group rows must not leak into fn ---
+
+test_that("omnibus assoc_test excludes total_group duplicate rows from fn (#53)", {
+  adsl <- data.frame(
+    USUBJID = 1:40,
+    TRT01P = factor(rep(c("Placebo", "Low", "High", "Xtra"), each = 10),
+                    levels = c("Placebo", "Low", "High", "Xtra")),
+    AGEGR1 = c(rep("<65", 6), rep(">=65", 4), rep("<65", 3), rep(">=65", 7),
+               rep("<65", 8), rep(">=65", 2), rep("<65", 5), rep(">=65", 5)),
+    stringsAsFactors = FALSE)
+
+  seen <- NULL
+  chi_fn <- function(.data) {
+    seen <<- .data
+    sprintf("%.4f", suppressWarnings(
+      chisq.test(table(.data$TRT01P, .data$AGEGR1))$p.value))
+  }
+  b <- tplyr_build(tplyr_spec(cols = "TRT01P",
+    total_groups = list(total_group("TRT01P")),
+    layers = tplyr_layers(group_count("AGEGR1", settings = layer_settings(
+      format_strings = list(n_counts = f_str("xx", "n")),
+      assoc_test = assoc_test(fn = chi_fn, format = f_str("x.xxxx", "p")))))), adsl)
+
+  # fn saw only the 40 real rows, no synthetic "Total" arm, no marker column
+  expect_equal(nrow(seen), 40L)
+  expect_false("Total" %in% as.character(seen$TRT01P))
+  expect_false("Total" %in% levels(seen$TRT01P))   # phantom level dropped too
+  expect_false(".tplyr_synthetic" %in% names(seen))
+  # and the reported p equals a direct test on the real data
+  expected <- sprintf("%.4f", suppressWarnings(
+    chisq.test(table(adsl$TRT01P, adsl$AGEGR1))$p.value))
+  expect_equal(trimws(b$pval1[b$pval1 != ""][1]), expected)
+})
+
+test_that("omnibus assoc_test excludes custom_group duplicate rows from fn (#53)", {
+  d <- data.frame(
+    TRT = factor(rep(c("Placebo", "Low", "High"), each = 10),
+                 levels = c("Placebo", "Low", "High")),
+    RESP = factor(rep(c("N", "Y"), 15), levels = c("N", "Y")),
+    stringsAsFactors = FALSE)
+  seen_n <- NULL
+  b <- tplyr_build(tplyr_spec(cols = "TRT",
+    custom_groups = list(custom_group("TRT", "Active" = c("Low", "High"))),
+    layers = tplyr_layers(group_count("RESP", settings = layer_settings(
+      format_strings = list(n_counts = f_str("xx", "n")),
+      assoc_test = assoc_test(
+        fn = function(.data) { seen_n <<- nrow(.data); 0.5 },
+        format = f_str("x.xxx", "p")))))), d)
+  # the "Active" duplicates (20 rows) are excluded -> fn sees only the 30 real
+  expect_equal(seen_n, 30L)
+})
+
+# --- #54: omnibus value lands on the first DISPLAY row, not the pre-sort row ---
+
+test_that("omnibus assoc_test places the value on the first display row (#54)", {
+  d2 <- data.frame(
+    TRT = factor(rep(c("A", "B"), each = 15), levels = c("A", "B")),
+    AGEGR1 = factor(c(rep("<65", 8), rep("65-80", 4), rep(">80", 3),
+                      rep("<65", 3), rep("65-80", 9), rep(">80", 3)),
+                    levels = c("<65", "65-80", ">80")),
+    stringsAsFactors = FALSE)
+  at <- assoc_test(
+    fn = function(.data) suppressWarnings(
+      chisq.test(table(.data$TRT, .data$AGEGR1))$p.value),
+    format = f_str("x.xxx", "p"))
+  disp <- as.data.frame(as_display(tplyr_build(tplyr_spec(cols = "TRT",
+    layers = tplyr_layers(group_count("AGEGR1", settings = layer_settings(
+      format_strings = list(n_counts = f_str("xx", "n")),
+      order_count_method = "byfactor", assoc_test = at)))), d2)))
+
+  # value on the first factor-order row (<65), blank on the rest
+  expect_true(trimws(disp$pval1[disp$rowlabel1 == "<65"]) != "")
+  expect_equal(trimws(disp$pval1[disp$rowlabel1 == "65-80"]), "")
+  expect_equal(trimws(disp$pval1[disp$rowlabel1 == ">80"]), "")
+})
+
+test_that("omnibus assoc_test lands on each by-group's first display row (#54)", {
+  set.seed(9)
+  d <- data.frame(
+    TRT = factor(rep(c("A", "B"), each = 30), levels = c("A", "B")),
+    PARAM = factor(rep(c("ALT", "AST"), 30), levels = c("ALT", "AST")),
+    GR = factor(sample(c("Hi", "Lo", "Mid"), 60, replace = TRUE),
+                levels = c("Lo", "Mid", "Hi")),
+    stringsAsFactors = FALSE)
+  at <- assoc_test(
+    fn = function(.data) suppressWarnings(
+      chisq.test(table(.data$TRT, .data$GR))$p.value),
+    format = f_str("x.xxx", "p"))
+  disp <- as.data.frame(as_display(tplyr_build(tplyr_spec(cols = "TRT",
+    layers = tplyr_layers(group_count("GR", by = "PARAM", settings = layer_settings(
+      format_strings = list(n_counts = f_str("xx", "n")),
+      order_count_method = "byfactor", assoc_test = at)))), d)))
+
+  # within each PARAM, exactly one value and it is on the first factor row (Lo)
+  for (p in c("ALT", "AST")) {
+    grp <- disp[disp$rowlabel1 == p, ]
+    grp <- grp[order(match(grp$rowlabel2, c("Lo", "Mid", "Hi"))), ]
+    expect_equal(sum(trimws(grp$pval1) != ""), 1L)
+    expect_true(trimws(grp$pval1[grp$rowlabel2 == "Lo"]) != "")
+  }
+})

--- a/vignettes/binding-statistics.Rmd
+++ b/vignettes/binding-statistics.Rmd
@@ -82,8 +82,28 @@ kable(as_display(b))
 The p-value sits in the trailing `pval1` column on the first row. Your `fn`
 receives the raw rows, so any test that works on a data frame works here.
 
-**Pairwise / per-level mode** (new in 0.2.0) is switched on by supplying
-`comparisons`. It compares a `reference` arm to each other arm, emits one
+Omnibus mode also works on a **`group_desc`** layer — the natural home for a
+**continuous** comparison across arms (ANOVA, Kruskal-Wallis, a t-test). The
+contract is identical (one p per `by` group, on that group's first statistic
+row), so a demographics table gets its continuous p-values the same way its
+categorical ones do, sharing a single `pval1` column:
+
+```{r assoc-desc}
+spec_age <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(
+    group_desc("AGE",
+      settings = layer_settings(
+        format_strings = list(Mean = f_str("xx.x", "mean"), SD = f_str("xx.xx", "sd")),
+        assoc_test = assoc_test(
+          fn = function(.data) anova(lm(AGE ~ TRT01P, .data))[["Pr(>F)"]][1],
+          format = f_str("x.xxx", "p"), label = "ANOVA p")))))
+
+kable(as_display(tplyr_build(spec_age, tplyr_adsl)))
+```
+
+**Pairwise / per-level mode** (new in 0.2.0, count layers only) is switched on by
+supplying `comparisons`. It compares a `reference` arm to each other arm, emits one
 `pval<k>` column per comparison with a value on **every** target-level row, and
 hands your `fn` a ready-made incidence 2x2 per (level, comparison) built from
 the assembled counts *and* population denominators:


### PR DESCRIPTION
Closes #51.

## What

`assoc_test()` brought an inferential p-value column to count and shift layers, but a **continuous** comparison across arms — ANOVA / Kruskal-Wallis / t-test — had no home because it wasn't wired into **`group_desc`**. A desc-layer `assoc_test` was accepted without error but silently produced nothing.

It now works in **omnibus mode** on desc layers, with the exact same contract as count/shift: the `fn` receives the by-group's raw source-data subset (all `cols` levels), returns a scalar p (formatted by `format`) or a verbatim character string (per #47), placed on the by-group's first output row; `NA` → blank.

```r
group_desc("AGE", settings = layer_settings(
  format_strings = list(Mean = f_str("xx.x","mean"), SD = f_str("xx.xx","sd")),
  assoc_test = assoc_test(fn = function(.data) anova(lm(AGE ~ TRT, .data))[["Pr(>F)"]][1],
                          format = f_str("x.xxx","p"))))
#>   rowlabel1  res1  res2  res3 pval1
#> 1      Mean  76.5  73.9  77.1 0.315   <- ANOVA p on the first stat row
#> 2        SD  7.31  6.97  6.48
```

The payoff: a demographics table's **continuous and categorical** characteristics now share one `pval1` column, produced entirely through tplyr2 instead of a hand-rolled `aov`/`kruskal.test` side pipeline.

## How

`build_desc_layer()` runs `compute_assoc_test()` once per by-group and places the result via `merge_assoc_column()` — the same omnibus helpers count/shift already use. The merge runs **after** the `stats_as_columns` transpose, so the with-`by` transposed layout (one row per by-group) is covered too.

Pairwise/per-level mode builds a per-target-level 2×2, which only a count layer has — so supplying `comparisons` on a desc (or any non-count) layer is now a **clear validation error** instead of being silently ignored.

## Scope note

Omnibus `fn` is not target-aware (it receives the by-group frame, not the target-variable name). So the natural shapes are a single-target desc (± a `by` grouping, one p per characteristic) — exactly the demographics case. On a multi-target desc the single omnibus scalar lands once per by-group on the first matching block.

## Tests / docs

- New desc tests: single + by-group placement, value checked against a direct `anova()`, character passthrough, `NA`-blanking, the pairwise-on-desc error, and a count+desc spec sharing one `pval` column. Full suite green (**1288 passing**).
- `assoc_test()` roxygen (title/Details/example), the `layer_settings` applicability table + `assoc_test` param, a `NEWS.md` bullet, and a runnable desc example in the *Comparative Statistics* vignette.

## Also fixes two silent omnibus `assoc_test` bugs (#53, #54)

Both surfaced while wiring up the demographics table this PR enables, and both fail **silently** — a well-formed but wrong number, or a value on the wrong row — so they're folded in here.

Closes #53 — **`total_group()`/`custom_group()` rows leaked into the omnibus `fn`'s `.data`.** They're a display construct for the count columns; including them double-counted every subject and returned a wrong p-value with no error/warning (a chi-square that should be `0.1542` came back `0.2624`). The duplicates are now tagged with an internal `.tplyr_synthetic` marker and dropped before `fn` runs — along with their now-unused factor levels (a phantom `"Total"` level otherwise made `chisq.test()` return `NaN`). The count columns (including the Total display column), `numeric_data`, and metadata are unchanged; the marker never reaches output.

Closes #54 — **the omnibus p-value landed on an arbitrary category row.** It was written to the first row of the pre-sort (dcast) frame, but the `ord*`/`byfactor` reorder is applied afterward, so it stranded on the wrong row (e.g. `65-80` instead of `<65`). `merge_assoc_column()` now derives the display order from the `ord*` columns and places the value on the first row of each by-group in that final order.

Regression tests added for each (total_group + custom_group leak; byfactor placement with and without a `by` variable). Full suite now **1301 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
