### PR TITLE
Fix denom_row "NA" for absent baseline group + add denom_row_format (#55)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -116,6 +116,13 @@
 
 ## Bug fixes
 
+- `group_shift(denom_row = TRUE)` no longer renders the literal string `"NA"`
+  for a baseline (shift-column) group that is absent within a `by` group (#55);
+  an absent group's denominator is zero, so the cell now reads `0` (consistent
+  with `zero_count_display` on the shift-to rows). A new `denom_row_format`
+  setting also lets the denominator row carry its own `f_str` width independent
+  of the `n_counts` cells (e.g. `denom_row_format = f_str("xx", "n")` for a plain
+  narrow integer) instead of inheriting their padding.
 - Omnibus `assoc_test()` no longer lets `total_group()` / `custom_group()`
   duplicate rows leak into the `fn`'s `.data` (#53). Those rows are a display
   construct for the count columns; including them double-counted every subject

--- a/R/build_shift.R
+++ b/R/build_shift.R
@@ -151,8 +151,21 @@ build_shift_layer <- function(dt, layer, cols, layer_index, col_n = NULL, pop_dt
     denom_label <- settings$denom_row_label %||% "n"
     dr <- unique(counts[, c(all_cols, by_data_vars, "total"), with = FALSE])
     dr[, (row_var) := denom_label]
-    fmt_w <- max(nchar(counts[["formatted"]]), na.rm = TRUE)
-    dr[, formatted := formatC(total, format = "d", width = fmt_w)]
+    # A baseline (shift-column) group that is absent for a by-group has no
+    # denominator row in `denoms`, so completion leaves `total` NA. Its
+    # denominator is zero, not unknown; zero-fill it so the cell renders 0
+    # rather than the literal string "NA" (#55).
+    dr[is.na(total), total := 0L]
+    denom_fmt <- settings$denom_row_format
+    if (!is.null(denom_fmt)) {
+      # Format the denominator with its own f_str (passed positionally), so the
+      # row's width is independent of the n_counts cells (#55).
+      dr[, formatted := apply_formats(denom_fmt, total)]
+    } else {
+      # Legacy behavior: right-align the integer to the shift-cell width.
+      fmt_w <- max(nchar(counts[["formatted"]]), na.rm = TRUE)
+      dr[, formatted := formatC(total, format = "d", width = fmt_w)]
+    }
     build_shift_row_labels(dr, by_labels, by_data_vars, row_var)
     dr[, .row_order := 0L]
     for (bv in by_data_vars) {

--- a/R/layer_settings.R
+++ b/R/layer_settings.R
@@ -16,6 +16,7 @@
 #' | `shift_denom` | | | X | |
 #' | `denom_row` | | | X | |
 #' | `denom_row_label` | | | X | |
+#' | `denom_row_format` | | | X | |
 #' | `denom_where` | X | X | X | |
 #' | `denom_ignore` | X | | X | |
 #' | `distinct_by` | X | | X | |
@@ -78,6 +79,14 @@
 #'   \code{shift_denom = "column"}. Defaults to \code{FALSE}.
 #' @param denom_row_label Character string, the row label for the \code{denom_row}
 #'   row. Defaults to \code{"n"}.
+#' @param denom_row_format An \code{\link{f_str}} object formatting the
+#'   \code{denom_row} cells, shift layers only. Lets the denominator row carry
+#'   its own width independent of the \code{n_counts} format (e.g.
+#'   \code{f_str("xx", "n")} for a plain narrow integer). The f_str must
+#'   reference a single variable (the denominator count is passed positionally).
+#'   \code{NULL} (default) keeps the legacy behavior of padding the integer to
+#'   the width of the shift cells. An absent baseline group renders as \code{0}
+#'   either way.
 #' @param denom_where Expression for separate denominator filter
 #' @param denom_ignore Character vector of values to exclude from denominators
 #' @param distinct_by Character string naming the variable for distinct counting
@@ -136,6 +145,7 @@ layer_settings <- function(
     shift_denom = "total",
     denom_row = FALSE,
     denom_row_label = "n",
+    denom_row_format = NULL,
     denom_where = NULL,
     denom_ignore = NULL,
     distinct_by = NULL,
@@ -179,6 +189,7 @@ layer_settings <- function(
       shift_denom = shift_denom,
       denom_row = denom_row,
       denom_row_label = denom_row_label,
+      denom_row_format = denom_row_format,
       denom_where = denom_where,
       denom_ignore = denom_ignore,
       distinct_by = distinct_by,

--- a/R/serialize.R
+++ b/R/serialize.R
@@ -141,6 +141,11 @@ serialize_settings <- function(settings) {
     out$stat_columns <- map(settings$stat_columns, serialize_f_str)
   }
 
+  # denom_row_format: a single f_str
+  if (!is.null(settings$denom_row_format)) {
+    out$denom_row_format <- serialize_f_str(settings$denom_row_format)
+  }
+
   # Simple pass-through fields
   simple_fields <- c("denoms_by", "shift_denom", "denom_row", "denom_row_label",
                       "denom_ignore", "distinct_by",
@@ -447,6 +452,11 @@ deserialize_settings <- function(raw) {
   # Reconstruct stat_columns
   if (!is.null(raw$stat_columns)) {
     raw$stat_columns <- map(raw$stat_columns, deserialize_f_str)
+  }
+
+  # Reconstruct denom_row_format
+  if (!is.null(raw$denom_row_format)) {
+    raw$denom_row_format <- deserialize_f_str(raw$denom_row_format)
   }
 
   # Reconstruct denom_where

--- a/R/validate.R
+++ b/R/validate.R
@@ -137,6 +137,20 @@ validate_layer <- function(layer, index, cols = NULL) {
          call. = FALSE)
   }
 
+  # denom_row_format (shift layers): a single-variable f_str
+  drf <- layer$settings$denom_row_format
+  if (!is.null(drf)) {
+    if (!inherits(drf, "tplyr_f_str")) {
+      stop(str_glue("Layer {index}: denom_row_format must be an f_str() object"),
+           call. = FALSE)
+    }
+    if (length(drf$vars) != 1) {
+      stop(str_glue("Layer {index}: denom_row_format must reference exactly one ",
+                    "variable (the denominator count)"),
+           call. = FALSE)
+    }
+  }
+
   # Validate single-proportion CI settings (count layers)
   ci_method <- layer$settings$ci_method
   ci_methods <- c("clopper_pearson", "wilson", "wald", "agresti_coull",

--- a/man/layer_settings.Rd
+++ b/man/layer_settings.Rd
@@ -11,6 +11,7 @@ layer_settings(
   shift_denom = "total",
   denom_row = FALSE,
   denom_row_label = "n",
+  denom_row_format = NULL,
   denom_where = NULL,
   denom_ignore = NULL,
   distinct_by = NULL,
@@ -78,6 +79,15 @@ threshold/normal-range shift table. Pairs naturally with
 
 \item{denom_row_label}{Character string, the row label for the \code{denom_row}
 row. Defaults to \code{"n"}.}
+
+\item{denom_row_format}{An \code{\link{f_str}} object formatting the
+\code{denom_row} cells, shift layers only. Lets the denominator row carry
+its own width independent of the \code{n_counts} format (e.g.
+\code{f_str("xx", "n")} for a plain narrow integer). The f_str must
+reference a single variable (the denominator count is passed positionally).
+\code{NULL} (default) keeps the legacy behavior of padding the integer to
+the width of the shift cells. An absent baseline group renders as \code{0}
+either way.}
 
 \item{denom_where}{Expression for separate denominator filter}
 
@@ -175,6 +185,7 @@ settings are applicable for each of the four layer types:\tabular{lllll}{
    \code{shift_denom} \tab  \tab  \tab X \tab  \cr
    \code{denom_row} \tab  \tab  \tab X \tab  \cr
    \code{denom_row_label} \tab  \tab  \tab X \tab  \cr
+   \code{denom_row_format} \tab  \tab  \tab X \tab  \cr
    \code{denom_where} \tab X \tab X \tab X \tab  \cr
    \code{denom_ignore} \tab X \tab  \tab X \tab  \cr
    \code{distinct_by} \tab X \tab  \tab X \tab  \cr

--- a/tests/testthat/test-build_shift.R
+++ b/tests/testthat/test-build_shift.R
@@ -467,3 +467,74 @@ test_that("group_shift denom_row emits an n row above the shift-to rows", {
   expect_equal(trimws(b[[n_col]][1]), "8")
   expect_equal(trimws(b[[h_col]][1]), "4")
 })
+
+# Issue #55: absent baseline group must render 0 (not literal "NA"), and the
+# denom row can carry its own format independent of the n_counts width.
+.denom_row_absent_data <- function() {
+  d <- data.frame(
+    TRTP   = factor(rep(c("Pbo", "Act"), each = 8), levels = c("Pbo", "Act")),
+    PARAM  = rep(c("A", "B"), 8),
+    BNRIND = factor(c("N","N","H","N","N","N","H","N", "N","N","H","N","N","N","H","N"),
+                    levels = c("N", "H")),
+    ANRIND = factor(c("N","H","H","N","N","H","N","N", "N","H","H","N","N","H","N","N"),
+                    levels = c("N", "H")),
+    stringsAsFactors = FALSE)
+  d$BNRIND[d$PARAM == "B"] <- "N"   # PARAM B: baseline High entirely absent
+  d
+}
+
+test_that("denom_row zero-fills an absent baseline group instead of NA (#55)", {
+  d <- .denom_row_absent_data()
+  b <- tplyr_build(tplyr_spec(cols = "TRTP", layers = tplyr_layers(
+    group_shift(c(row = "ANRIND", column = "BNRIND"), by = "PARAM",
+      settings = layer_settings(
+        shift_denom = "column", zero_count_display = "count_only",
+        format_strings = list(n_counts = f_str("xx(xxx%)", "n", "pct")),
+        denom_row = TRUE, denom_row_label = "n")))), d)
+
+  res_cols <- grep("^res\\d+$", names(b), value = TRUE)
+  denom <- b[trimws(b$rowlabel2) == "n", ]
+  cells <- unlist(lapply(res_cols, function(rc) trimws(denom[[rc]])))
+  # never the literal string "NA"; the absent (PARAM B, High) group reads 0
+  expect_false(any(cells == "NA"))
+  b_row <- denom[trimws(denom$rowlabel1) == "B", ]
+  expect_true(any(vapply(res_cols, function(rc) trimws(b_row[[rc]]) == "0", logical(1))))
+})
+
+test_that("denom_row_format gives the n row its own width (#55)", {
+  d <- .denom_row_absent_data()
+  b <- tplyr_build(tplyr_spec(cols = "TRTP", layers = tplyr_layers(
+    group_shift(c(row = "ANRIND", column = "BNRIND"), by = "PARAM",
+      settings = layer_settings(
+        shift_denom = "column", zero_count_display = "count_only",
+        format_strings = list(n_counts = f_str("xx(xxx%)", "n", "pct")),
+        denom_row = TRUE, denom_row_label = "n",
+        denom_row_format = f_str("xx", "n"))))), d)
+
+  res_cols <- grep("^res\\d+$", names(b), value = TRUE)
+  denom <- b[trimws(b$rowlabel2) == "n", ]
+  # 2-char field (independent of the 8-char n_counts cells), right-justified
+  widths <- unlist(lapply(res_cols, function(rc) nchar(denom[[rc]])))
+  expect_true(all(widths == 2))
+  b_row <- denom[trimws(denom$rowlabel1) == "B", ]
+  vals <- vapply(res_cols, function(rc) b_row[[rc]], character(1))
+  expect_true(all(vals %in% c(" 2", " 4", " 0")))
+})
+
+test_that("denom_row_format must be a single-variable f_str (#55)", {
+  d <- .denom_row_absent_data()
+  expect_error(
+    tplyr_build(tplyr_spec(cols = "TRTP", layers = tplyr_layers(
+      group_shift(c(row = "ANRIND", column = "BNRIND"),
+        settings = layer_settings(denom_row = TRUE,
+          denom_row_format = "xx")))), d),
+    "denom_row_format must be an f_str"
+  )
+  expect_error(
+    tplyr_build(tplyr_spec(cols = "TRTP", layers = tplyr_layers(
+      group_shift(c(row = "ANRIND", column = "BNRIND"),
+        settings = layer_settings(denom_row = TRUE,
+          denom_row_format = f_str("xx (xx)", "n", "pct"))))), d),
+    "exactly one"
+  )
+})

--- a/tests/testthat/test-serialize.R
+++ b/tests/testthat/test-serialize.R
@@ -541,6 +541,19 @@ test_that("JSON roundtrip preserves denom_row / denom_row_label", {
   expect_equal(s$denom_row_label, "N assessed")
 })
 
+test_that("JSON roundtrip preserves denom_row_format f_str (#55)", {
+  spec <- tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_shift(c(row = "BR", column = "AR"), settings = layer_settings(
+      shift_denom = "column", denom_row = TRUE,
+      denom_row_format = f_str("xx", "n")))))
+  path <- file.path(scratch_dir, "denom_row_format.json")
+  tplyr_write_spec(spec, path)
+  s <- tplyr_read_spec(path)$layers[[1]]$settings
+  expect_s3_class(s$denom_row_format, "tplyr_f_str")
+  expect_equal(s$denom_row_format$format_string, "xx")
+  expect_equal(s$denom_row_format$vars, "n")
+})
+
 # --- Single-proportion CI settings roundtrip (#44) ---
 
 test_that("JSON roundtrip preserves ci_method / ci_level and CI keywords", {


### PR DESCRIPTION
Closes #55.

Two problems with the shift `denom_row` setting (#35), both triggered as soon as a `by` group has an **absent baseline (shift-column) group**.

## 1. Literal `"NA"` in the denominator cell

An absent group has no row in `denoms`, so completion left `total` as `NA`, and `formatC(NA, ...)` emitted the string `"NA"` (a real character, not a true `NA`). An absent group's denominator is **zero**, so `denom_row` now zero-fills it — the cell reads `0`, consistent with what `zero_count_display` already does for the shift-to rows directly below.

## 2. Denominator row inherited the `n_counts` width

The `n` row was right-padded to the full `n_counts` width (`f_str("xx(xxx%)")` → 8 chars), with no independent control. New **`denom_row_format`** setting (an `f_str`) formats the denominator on its own:

```r
layer_settings(denom_row = TRUE, denom_row_label = "n",
               denom_row_format = f_str("xx", "n"))   # -> " 2" / " 4" / " 0"
```

`NULL` (default) keeps the legacy width-matching behavior, so this is backward compatible.

## Before / after (issue reprex — `PARAM "B"` has no baseline-High subjects)

```
# before                              # after (default)      # after (denom_row_format = f_str("xx","n"))
B  n   4   NA   4   NA                B  n   4   0   4   0    B  n   4  0  4  0
```

## Tests / docs

- Tests for both fixes (absent group → `0`, never `"NA"`; `denom_row_format` gives a 2-char field independent of the 8-char cells), `denom_row_format` validation (single-variable f_str), and a JSON round-trip. Full suite green (**1310 passing**).
- `denom_row_format` round-trips through serialization; `layer_settings` applicability table + param doc; NEWS bug-fix bullet.

With these, the pilot's shift tables can drop their parallel `count()`/`pivot_wider(values_fill = 0)` + `sprintf("%2d", .)` n-row and take the denominator from the layer that already computed it — the point of #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)