### PR TITLE
assoc_test(): let fn return multiple values into one cell (#60)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,15 @@
   `aov`/`kruskal.test` side pipeline. Pairwise/per-level mode remains count-layer
   only; supplying `comparisons` on a desc layer is now a clear error rather than
   silently ignored.
+- `assoc_test()`'s `fn` may now return **multiple values** rendered into one
+  cell (#60). When `format` references more than one variable, `fn` returns a
+  numeric vector of matching length, mapped positionally onto the format — so a
+  procedure that emits a tuple (an odds ratio with its confidence interval, an
+  estimate with a p-value) lands as a single formatted cell, e.g.
+  `f_str("xx.xx (xx.xx, xx.xx)", "or", "lo", "hi")`. A scalar return with a
+  one-variable format is unchanged; an all-`NA` return or an arity mismatch
+  renders a blank; the character-return passthrough (#47) still wins for a
+  finished display string.
 - New `shift_denom` setting for shift layers (#18). `shift_denom = "column"`
   computes percentages column-wise — out of each shift column group (the
   "from"/baseline group) within the treatment arm — the standard

--- a/R/assoc_test.R
+++ b/R/assoc_test.R
@@ -33,27 +33,31 @@
 #' rows are (reference, comparison) arm, columns are (event, no event) -- where
 #' \code{n} is the cell count and \code{N} the population denominator for that
 #' arm. When the layer sets \code{distinct_by}, the distinct counts/denominators
-#' are used. \code{fn} returns a scalar p-value -- numeric (formatted with
-#' \code{format}) or a verbatim character display string (\code{NA} renders a
-#' blank).
+#' are used. \code{fn} returns either a numeric value (a scalar, or a vector of
+#' several statistics matching a multi-variable \code{format}) or a verbatim
+#' character display string (\code{NA} renders a blank).
 #'
 #' Attach it to a layer via
 #' \code{layer_settings(assoc_test = assoc_test(...))}.
 #'
 #' @param fn A function of one argument. In omnibus mode it is called with the
 #'   source-data subset (a data.frame) for a single \code{by} group; in pairwise
-#'   mode it is called with a 2x2 numeric matrix (see Details). It returns a
-#'   single value that is rendered into the cell one of two ways: a
-#'   \strong{numeric} (typically a p-value) is formatted with \code{format}, or a
-#'   \strong{character} string is passed through \emph{verbatim} -- letting the
-#'   function that computes an arbitrary test also supply the finished display,
-#'   e.g. a significance flag (\code{"0.031*"}), a ceiling/floor
-#'   (\code{">.99"}, \code{"<.0001"}), or a sentinel (\code{"NE"}). Return
+#'   mode it is called with a 2x2 numeric matrix (see Details). Its return is
+#'   rendered into the cell one of two ways: a \strong{numeric} value (or a
+#'   numeric vector matching the number of variables in \code{format}) is
+#'   formatted with \code{format} -- a scalar p-value, or several statistics such
+#'   as an odds ratio with its confidence interval mapped positionally onto a
+#'   multi-variable f_str; or a \strong{character} string is passed through
+#'   \emph{verbatim}, letting the function that computes an arbitrary test also
+#'   supply the finished display (a significance flag \code{"0.031*"}, a
+#'   ceiling/floor \code{">.99"}/\code{"<.0001"}, a sentinel \code{"NE"}). Return
 #'   \code{NA} (numeric or character) to render a blank.
 #' @param format An \code{\link{f_str}} object formatting a \strong{numeric}
-#'   return; it is ignored when \code{fn} returns a character string. The f_str
-#'   must reference a single variable (any name; the returned scalar is passed
-#'   positionally). Defaults to \code{f_str("x.xxx", "p")}.
+#'   return; it is ignored when \code{fn} returns a character string. Its
+#'   variable count sets how many values \code{fn} must return: one variable for
+#'   a scalar (e.g. \code{f_str("x.xxx", "p")}, the default), or several for a
+#'   tuple (e.g. \code{f_str("xx.xx (xx.xx, xx.xx)", "or", "lo", "hi")}). The
+#'   returned values are passed positionally, so the variable names are free.
 #' @param label Character string used as the result column's header label. In
 #'   pairwise mode it may be a vector with one entry per comparison (or a single
 #'   value recycled across comparisons); \code{NULL} generates a default
@@ -94,6 +98,18 @@
 #'   fn = function(.data) anova(lm(AGE ~ TRT, .data))[["Pr(>F)"]][1],
 #'   format = f_str("x.xxx", "p")
 #' )
+#'
+#' # Multiple statistics in one cell: odds ratio with a confidence interval
+#' at4 <- assoc_test(
+#'   fn = function(m) {
+#'     ft <- fisher.test(m)
+#'     c(ft$estimate, ft$conf.int[1], ft$conf.int[2])
+#'   },
+#'   reference = "Placebo",
+#'   comparisons = c("Low", "High"),
+#'   format = f_str("xx.xx (xx.xx, xx.xx)", "or", "lo", "hi"),
+#'   label = "OR (95% CI)"
+#' )
 #' @export
 assoc_test <- function(fn, format = f_str("x.xxx", "p"), label = NULL,
                        reference = NULL, comparisons = NULL, total_row = TRUE) {
@@ -105,9 +121,8 @@ assoc_test <- function(fn, format = f_str("x.xxx", "p"), label = NULL,
   if (!inherits(format, "tplyr_f_str")) {
     stop("`format` must be an f_str() object", call. = FALSE)
   }
-  if (length(format$vars) != 1) {
-    stop("`format` must reference exactly one variable (the returned scalar)",
-         call. = FALSE)
+  if (length(format$vars) < 1) {
+    stop("`format` must reference at least one variable", call. = FALSE)
   }
   if (!is.logical(total_row) || length(total_row) != 1 || is.na(total_row)) {
     stop("`total_row` must be a single logical (TRUE/FALSE)", call. = FALSE)
@@ -177,30 +192,43 @@ print.tplyr_assoc_test <- function(x, ...) {
 
 #' Render an \code{assoc_test} \code{fn} return value for display
 #'
-#' Turns a single value returned by a caller-supplied \code{fn} into the string
-#' shown in the \code{pval} cell:
+#' Turns the value returned by a caller-supplied \code{fn} into the string shown
+#' in the \code{pval} cell:
 #' \itemize{
-#'   \item a length-1 \strong{numeric} (or logical) is formatted with
-#'     \code{config$format}; \code{NA} renders a blank;
+#'   \item a \strong{numeric} (or logical) vector whose length equals the number
+#'     of variables in \code{format} is mapped positionally onto the format and
+#'     rendered into one cell -- a scalar with a one-variable format (a p-value),
+#'     or several values with a multi-variable format (issue #60), e.g. an odds
+#'     ratio with a confidence interval. An all-\code{NA} return (or an arity
+#'     that does not match the format) renders a blank; a single \code{NA} field
+#'     within a longer return blanks just that field via the \code{f_str}
+#'     grammar;
 #'   \item a length-1 \strong{character} is passed through verbatim (issue #47),
 #'     so a caller computing an arbitrary test can also supply the finished
 #'     display (significance flags, \code{">.99"}/\code{"<.0001"} ceilings,
 #'     \code{"NE"} sentinels, trailing-space alignment); \code{NA_character_}
 #'     renders a blank;
-#'   \item anything else (wrong length, non-atomic) renders a blank.
+#'   \item anything else (non-atomic, mismatched length) renders a blank.
 #' }
 #'
 #' @param raw The raw value returned by \code{fn} (already wrapped so errors
 #'   arrive as \code{NA}).
-#' @param format An \code{\link{f_str}} object used for numeric returns.
+#' @param format An \code{\link{f_str}} object; its variable count determines how
+#'   many values a numeric return must supply.
 #' @return A length-1 character display string.
 #' @keywords internal
 format_assoc_return <- function(raw, format) {
-  if (length(raw) != 1) return("")
-  if (is.character(raw)) return(if (is.na(raw)) "" else raw)
+  # Character escape hatch: a single string is the whole cell, verbatim.
+  if (is.character(raw) && length(raw) == 1) {
+    return(if (is.na(raw)) "" else raw)
+  }
+  # Numeric/logical: map positionally onto the format's variables (one value per
+  # variable). One value + one-variable format is the classic scalar p-value.
   if (is.numeric(raw) || is.logical(raw)) {
-    if (is.na(raw)) return("")
-    return(apply_formats(format, as.numeric(raw)))
+    n_vars <- length(format$vars)
+    if (length(raw) != n_vars) return("")   # arity mismatch -> blank
+    if (all(is.na(raw))) return("")         # nothing to show -> blank
+    return(do.call(apply_formats, c(list(format), as.list(as.numeric(raw)))))
   }
   ""
 }

--- a/man/assoc_test.Rd
+++ b/man/assoc_test.Rd
@@ -16,19 +16,23 @@ assoc_test(
 \arguments{
 \item{fn}{A function of one argument. In omnibus mode it is called with the
 source-data subset (a data.frame) for a single \code{by} group; in pairwise
-mode it is called with a 2x2 numeric matrix (see Details). It returns a
-single value that is rendered into the cell one of two ways: a
-\strong{numeric} (typically a p-value) is formatted with \code{format}, or a
-\strong{character} string is passed through \emph{verbatim} -- letting the
-function that computes an arbitrary test also supply the finished display,
-e.g. a significance flag (\code{"0.031*"}), a ceiling/floor
-(\code{">.99"}, \code{"<.0001"}), or a sentinel (\code{"NE"}). Return
+mode it is called with a 2x2 numeric matrix (see Details). Its return is
+rendered into the cell one of two ways: a \strong{numeric} value (or a
+numeric vector matching the number of variables in \code{format}) is
+formatted with \code{format} -- a scalar p-value, or several statistics such
+as an odds ratio with its confidence interval mapped positionally onto a
+multi-variable f_str; or a \strong{character} string is passed through
+\emph{verbatim}, letting the function that computes an arbitrary test also
+supply the finished display (a significance flag \code{"0.031*"}, a
+ceiling/floor \code{">.99"}/\code{"<.0001"}, a sentinel \code{"NE"}). Return
 \code{NA} (numeric or character) to render a blank.}
 
 \item{format}{An \code{\link{f_str}} object formatting a \strong{numeric}
-return; it is ignored when \code{fn} returns a character string. The f_str
-must reference a single variable (any name; the returned scalar is passed
-positionally). Defaults to \code{f_str("x.xxx", "p")}.}
+return; it is ignored when \code{fn} returns a character string. Its
+variable count sets how many values \code{fn} must return: one variable for
+a scalar (e.g. \code{f_str("x.xxx", "p")}, the default), or several for a
+tuple (e.g. \code{f_str("xx.xx (xx.xx, xx.xx)", "or", "lo", "hi")}). The
+returned values are passed positionally, so the variable names are free.}
 
 \item{label}{Character string used as the result column's header label. In
 pairwise mode it may be a vector with one entry per comparison (or a single
@@ -89,9 +93,9 @@ comparison) pair, a 2x2 contingency \strong{matrix}
 rows are (reference, comparison) arm, columns are (event, no event) -- where
 \code{n} is the cell count and \code{N} the population denominator for that
 arm. When the layer sets \code{distinct_by}, the distinct counts/denominators
-are used. \code{fn} returns a scalar p-value -- numeric (formatted with
-\code{format}) or a verbatim character display string (\code{NA} renders a
-blank).
+are used. \code{fn} returns either a numeric value (a scalar, or a vector of
+several statistics matching a multi-variable \code{format}) or a verbatim
+character display string (\code{NA} renders a blank).
 
 Attach it to a layer via
 \code{layer_settings(assoc_test = assoc_test(...))}.
@@ -116,5 +120,17 @@ at2 <- assoc_test(
 at3 <- assoc_test(
   fn = function(.data) anova(lm(AGE ~ TRT, .data))[["Pr(>F)"]][1],
   format = f_str("x.xxx", "p")
+)
+
+# Multiple statistics in one cell: odds ratio with a confidence interval
+at4 <- assoc_test(
+  fn = function(m) {
+    ft <- fisher.test(m)
+    c(ft$estimate, ft$conf.int[1], ft$conf.int[2])
+  },
+  reference = "Placebo",
+  comparisons = c("Low", "High"),
+  format = f_str("xx.xx (xx.xx, xx.xx)", "or", "lo", "hi"),
+  label = "OR (95\% CI)"
 )
 }

--- a/man/format_assoc_return.Rd
+++ b/man/format_assoc_return.Rd
@@ -10,23 +10,30 @@ format_assoc_return(raw, format)
 \item{raw}{The raw value returned by \code{fn} (already wrapped so errors
 arrive as \code{NA}).}
 
-\item{format}{An \code{\link{f_str}} object used for numeric returns.}
+\item{format}{An \code{\link{f_str}} object; its variable count determines how
+many values a numeric return must supply.}
 }
 \value{
 A length-1 character display string.
 }
 \description{
-Turns a single value returned by a caller-supplied \code{fn} into the string
-shown in the \code{pval} cell:
+Turns the value returned by a caller-supplied \code{fn} into the string shown
+in the \code{pval} cell:
 \itemize{
-\item a length-1 \strong{numeric} (or logical) is formatted with
-\code{config$format}; \code{NA} renders a blank;
+\item a \strong{numeric} (or logical) vector whose length equals the number
+of variables in \code{format} is mapped positionally onto the format and
+rendered into one cell -- a scalar with a one-variable format (a p-value),
+or several values with a multi-variable format (issue #60), e.g. an odds
+ratio with a confidence interval. An all-\code{NA} return (or an arity
+that does not match the format) renders a blank; a single \code{NA} field
+within a longer return blanks just that field via the \code{f_str}
+grammar;
 \item a length-1 \strong{character} is passed through verbatim (issue #47),
 so a caller computing an arbitrary test can also supply the finished
 display (significance flags, \code{">.99"}/\code{"<.0001"} ceilings,
 \code{"NE"} sentinels, trailing-space alignment); \code{NA_character_}
 renders a blank;
-\item anything else (wrong length, non-atomic) renders a blank.
+\item anything else (non-atomic, mismatched length) renders a blank.
 }
 }
 \keyword{internal}

--- a/tests/testthat/test-assoc_test.R
+++ b/tests/testthat/test-assoc_test.R
@@ -3,8 +3,11 @@
 test_that("assoc_test validates its arguments", {
   expect_error(assoc_test(fn = "notafn"), "must be a function")
   expect_error(assoc_test(fn = function(d) 1, format = "x.xxx"), "f_str")
-  expect_error(assoc_test(fn = function(d) 1, format = f_str("xx xx", "a", "b")),
-               "exactly one variable")
+  # multi-variable formats are accepted (issue #60): fn may return a tuple
+  expect_s3_class(
+    assoc_test(fn = function(d) c(1, 2), format = f_str("xx (xx)", "a", "b")),
+    "tplyr_assoc_test"
+  )
 })
 
 test_that("assoc_test object prints", {
@@ -894,4 +897,75 @@ test_that("omnibus assoc_test lands on each by-group's first display row (#54)",
     expect_equal(sum(trimws(grp$pval1) != ""), 1L)
     expect_true(trimws(grp$pval1[grp$rowlabel2 == "Lo"]) != "")
   }
+})
+
+# --- Multiple values in one cell (#60) ---
+
+test_that("format_assoc_return maps a numeric vector onto a multi-variable f_str (#60)", {
+  fmt <- f_str("xx.xx (xx.xx, xx.xx)", "or", "lo", "hi")
+  # three values, three variables -> one formatted cell (fields are width-padded)
+  cell <- tplyr2:::format_assoc_return(c(1.85, 1.10, 3.02), fmt)
+  expect_match(cell, "^\\s*1\\.85 \\(\\s*1\\.10,\\s*3\\.02\\)$")
+  # arity mismatch (too few / too many) -> blank
+  expect_identical(tplyr2:::format_assoc_return(c(1.85, 1.10), fmt), "")
+  expect_identical(tplyr2:::format_assoc_return(c(1, 2, 3, 4), fmt), "")
+  # all-NA -> blank; a single NA field blanks just that field
+  expect_identical(tplyr2:::format_assoc_return(c(NA_real_, NA_real_, NA_real_), fmt), "")
+  partial <- tplyr2:::format_assoc_return(c(1.85, NA_real_, 3.02), fmt)
+  expect_true(grepl("1.85", partial))
+  # character escape hatch still wins, even with a multi-variable format
+  expect_identical(tplyr2:::format_assoc_return("NE", fmt), "NE")
+  # scalar + one-variable format is unchanged
+  expect_equal(trimws(tplyr2:::format_assoc_return(0.0312, f_str("x.xxx", "p"))), "0.031")
+})
+
+test_that("assoc_test constructor accepts a multi-variable format (#60)", {
+  at <- assoc_test(fn = function(m) c(1, 2, 3),
+                   format = f_str("xx (xx, xx)", "or", "lo", "hi"),
+                   reference = "Placebo", comparisons = "Low")
+  expect_s3_class(at, "tplyr_assoc_test")
+  expect_equal(length(at$format$vars), 3L)
+})
+
+test_that("pairwise assoc_test renders an odds ratio with CI in one cell (#60)", {
+  set.seed(4)
+  d <- data.frame(
+    TRT = factor(rep(c("Placebo", "Low", "High"), each = 40),
+                 levels = c("Placebo", "Low", "High")),
+    RESP = factor(sample(c("Y", "N"), 120, replace = TRUE), levels = c("N", "Y")))
+  at <- assoc_test(
+    fn = function(m) {
+      ft <- suppressWarnings(fisher.test(m))
+      c(ft$estimate, ft$conf.int[1], ft$conf.int[2])
+    },
+    reference = "Placebo", comparisons = c("Low", "High"),
+    format = f_str("xx.xx (xx.xx, xx.xx)", "or", "lo", "hi"),
+    label = "OR (95% CI)")
+  b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_count("RESP", settings = layer_settings(
+      format_strings = list(n_counts = f_str("xx", "n")), assoc_test = at)))), d)
+
+  expect_true(all(c("pval1", "pval2") %in% names(b)))
+  expect_equal(attr(b$pval1, "label"), "OR (95% CI)")
+  # cells look like "or (lo, hi)"
+  vals <- b$pval1[trimws(b$pval1) != ""]
+  expect_true(all(grepl("^\\s*[0-9.]+ \\([0-9. ]+, [0-9. ]+\\)$", vals)))
+})
+
+test_that("omnibus assoc_test renders multiple statistics in one cell (#60)", {
+  set.seed(5)
+  d <- data.frame(
+    TRT = factor(rep(c("A", "B"), each = 30)),
+    RESP = factor(sample(c("Y", "N"), 60, replace = TRUE)))
+  at <- assoc_test(
+    fn = function(.data) {
+      ch <- suppressWarnings(chisq.test(table(.data$TRT, .data$RESP)))
+      c(unname(ch$statistic), ch$p.value)
+    },
+    format = f_str("xx.x (p=x.xxx)", "stat", "p"), label = "chi-square")
+  b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_count("RESP", settings = layer_settings(
+      format_strings = list(n_counts = f_str("xx", "n")), assoc_test = at)))), d)
+  val <- b$pval1[trimws(b$pval1) != ""][1]
+  expect_true(grepl("p=", val))
 })


### PR DESCRIPTION
Closes #60.

## What

`assoc_test()`'s `fn` was limited to a single scalar (a p-value). Many statistical procedures naturally emit a small **tuple** per comparison — an odds ratio with its CI, an estimate with a p-value — and the only way to show them was a hand-formatted string that threw away the `f_str` formatting.

`fn` may now return a **numeric vector** whose length matches the number of variables in `format`, mapped positionally onto the f_str and rendered into one cell:

```r
assoc_test(
  fn = function(m) { ft <- fisher.test(m); c(ft$estimate, ft$conf.int[1], ft$conf.int[2]) },
  reference = "Placebo", comparisons = c("Low", "High"),
  format = f_str("xx.xx (xx.xx, xx.xx)", "or", "lo", "hi"),
  label = "OR (95% CI)"
)
# -> cells like "1.85 (1.10, 3.02)"
```

This turns `assoc_test()` from "p-value column" into "any per-comparison statistical result," and is the mechanism that would let `risk_diff` become a preset of `assoc_test` later.

## How (Option A from the design in #60)

Deliberately **one richer cell**, not multiple columns — so the per-comparison placement/merge machinery is untouched (a cell is still a single string). The change is localized:

- `format_assoc_return()` now maps a length-matched numeric vector onto the format via `do.call(apply_formats, ...)`; the length-1 character passthrough (#47) and the NA/arity-mismatch → blank rules are preserved.
- The `assoc_test()` constructor's "exactly one variable" check relaxes to "at least one."
- `pairwise_cell_disp()` / omnibus `run_one()` unchanged (they delegate to `format_assoc_return()`); serialization unchanged (`format` is already an `f_str`).

## Behavior

- **Backward compatible:** a scalar return with a one-variable format behaves exactly as before (verified against existing tests).
- All-`NA` return or an arity mismatch → blank cell; a single `NA` field blanks just that field via the `f_str` grammar; a length-1 character return still passes through verbatim.
- Works in both omnibus and pairwise modes.
- Column stays `pval<k>`; the caller-set `label` carries the meaning (e.g. `"OR (95% CI)"`).

## Tests / docs

- New tests: `format_assoc_return` vector mapping + arity/NA/passthrough edge cases, constructor acceptance of a multi-variable format, and pairwise (OR+CI) + omnibus multi-value builds. Full suite green (**1323 passing**).
- `assoc_test()` roxygen (`fn`/`format` params + an OR-with-CI example) and a `NEWS.md` bullet.

## Follow-ons (noted in #60, not here)

- `risk_diff` as a preset on top of this (also needs #58).
- Landing the multiple values in `numeric_data`/ARD — assoc results are display-only today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)