### PR TITLE
Error loudly when risk_diff is set on a nested count layer (#58)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -116,6 +116,12 @@
 
 ## Bug fixes
 
+- `risk_diff` on a **nested** count layer now errors instead of silently
+  emitting an all-blank column (#58). Risk difference is computed only on
+  single-level count layers; on a nested SOC/PT layer the setting previously
+  produced an empty `rdiff` column with no warning. The error points to
+  pairwise `assoc_test()`, which does compute a per-level comparison on nested
+  layers.
 - `group_shift(denom_row = TRUE)` no longer renders the literal string `"NA"`
   for a baseline (shift-column) group that is absent within a `by` group (#55);
   an absent group's denominator is zero, so the cell now reads `0` (consistent

--- a/R/validate.R
+++ b/R/validate.R
@@ -137,6 +137,19 @@ validate_layer <- function(layer, index, cols = NULL) {
          call. = FALSE)
   }
 
+  # risk_diff is computed only on single-level count layers. On a nested count
+  # layer it would otherwise emit a silently-blank column (issue #58); fail
+  # loudly and point to pairwise assoc_test(), which does work per-level on
+  # nested layers.
+  if (!is.null(layer$settings$risk_diff) &&
+      inherits(layer, "tplyr_count_layer") &&
+      length(layer$target_var) > 1) {
+    stop(str_glue("Layer {index}: risk_diff is not supported on nested count ",
+                  "layers. Use a pairwise assoc_test() for a per-level ",
+                  "comparison column (see vignette(\"binding-statistics\"))."),
+         call. = FALSE)
+  }
+
   # denom_row_format (shift layers): a single-variable f_str
   drf <- layer$settings$denom_row_format
   if (!is.null(drf)) {

--- a/tests/testthat/test-risk_diff.R
+++ b/tests/testthat/test-risk_diff.R
@@ -300,3 +300,24 @@ test_that("risk_diff respects a custom ci level", {
   result <- tplyr_build(spec, d)
   expect_true(any(grepl("^rdiff", names(result))))
 })
+
+test_that("risk_diff on a nested count layer errors loudly (#58)", {
+  d <- data.frame(
+    TRT = factor(rep(c("Placebo", "Active"), each = 20), levels = c("Placebo", "Active")),
+    SOC = rep(c("GI", "NERVOUS"), 20),
+    PT  = rep(c("NAUSEA", "HEADACHE"), 20),
+    stringsAsFactors = FALSE
+  )
+  spec <- tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_count(c("SOC", "PT"), settings = layer_settings(
+      risk_diff = list(comparisons = list(c("Active", "Placebo")))))))
+  expect_error(tplyr_build(spec, d),
+               "risk_diff is not supported on nested count layers")
+
+  # single-level risk_diff is unaffected
+  spec1 <- tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_count("PT", settings = layer_settings(
+      risk_diff = list(comparisons = list(c("Active", "Placebo")))))))
+  expect_silent(b <- tplyr_build(spec1, d))
+  expect_true("rdiff1" %in% names(b))
+})


### PR DESCRIPTION
Closes #58.

## What

`risk_diff` on a **nested** count layer silently emitted an all-blank `rdiff` column — no error, no warning. Risk difference is only wired into the single-level count path (`build_count_layer_single`), so on a nested SOC/PT layer it computed nothing.

`validate_layer()` now **rejects** `risk_diff` on a nested count layer with a clear message pointing to pairwise `assoc_test()`:

```
Layer 1: risk_diff is not supported on nested count layers. Use a pairwise
assoc_test() for a per-level comparison column (see vignette("binding-statistics")).
```

## Why error rather than implement it

As discussed on #58: pairwise `assoc_test()` already produces a per-level comparison column on nested layers (#49), and with #60 (multi-value returns) it can return a full risk-difference-with-CI tuple into one cell. So wiring a parallel `risk_diff` implementation into the nested path would be redundant. The right fix for the silent-failure bug is to fail loudly and route users to the tool that works. (If `risk_diff` later becomes a preset of `assoc_test`, this guard can relax and it closes by construction.)

Single-level `risk_diff` is completely unchanged.

## Tests

- New test: `risk_diff` on a nested layer errors; single-level `risk_diff` still builds an `rdiff` column. Full suite green (**1313 passing**). No existing test combined `risk_diff` with a nested target, so nothing regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)