### PR TITLE
Make count-layer sort settings actually work: bycount, ordering_cols, outer_sort_position (#57)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -116,6 +116,17 @@
 
 ## Bug fixes
 
+- Count-layer row ordering now honors the sort settings it advertised (#57).
+  `order_count_method = "bycount"` actually sorts by descending count (it
+  previously fell back to the default order); `ordering_cols` selects which
+  column's count drives that sort, and `result_order_var` which statistic;
+  `outer_sort_position = "desc"` reverses a nested layer's outer level. Any
+  explicit `order_count_method` (and the default) now also keeps `by`-groups
+  **blocked** instead of interleaving them, and the default respects the target
+  variable's factor levels (previously it ordered the target alphabetically
+  even when it was a factor). The target sort key is threaded through the cast
+  so all methods compose correctly with by-groups and special (total/missing)
+  rows.
 - `group_shift(denom_row = TRUE)` no longer renders the literal string `"NA"`
   for a baseline (shift-column) group that is absent within a `by` group (#55);
   an absent group's denominator is zero, so the cell now reads `0` (consistent

--- a/R/build_count.R
+++ b/R/build_count.R
@@ -226,36 +226,22 @@ build_count_layer_single <- function(dt, tv, cols, by_data_vars, by_labels,
   # (mirrors the shift layer) and drop them afterward.
   # `.is_special` sits between the by keys and the row labels so special rows
   # (total/missing) sort after the normal rows within each by-group (#24).
+  # The target sort key `.ord_tv` (computed above per output row: factor level,
+  # VARN, aggregated count, or alphabetical, per order_count_method) sits between
+  # the by-group keys and the row labels in the dcast LHS. This orders the target
+  # values within each by-group by the chosen method while keeping by-groups
+  # blocked and special rows (.is_special) last -- so ord1, taken from the dcast
+  # row order, reflects the full intended order for every method (issue #57).
   by_order_cols <- str_subset(names(counts), "^\\.ord_by_\\d+$")
   special_col <- if (".is_special" %in% names(counts)) ".is_special" else character(0)
-  drop_cols <- c(by_order_cols, special_col)
-  wide <- cast_to_wide(counts, c(by_order_cols, special_col, row_labels), cols,
-                       layer_index, col_n = col_n, stat_labels = names(fmts),
+  tv_order_col <- if (".ord_tv" %in% names(counts)) ".ord_tv" else character(0)
+  drop_cols <- c(by_order_cols, special_col, tv_order_col)
+  wide <- cast_to_wide(counts,
+                       c(by_order_cols, special_col, tv_order_col, row_labels),
+                       cols, layer_index, col_n = col_n, stat_labels = names(fmts),
                        col_levels = get_col_levels(dt, cols))
   for (oc in drop_cols) {
     if (oc %in% names(wide)) wide[, (oc) := NULL]
-  }
-
-  # --- Override ord1 with computed sort keys ---
-  method <- settings$order_count_method
-  if (!is.null(method)) {
-    # Find the rowlabel column that holds the target variable values
-    tv_label_idx <- length(by_labels) + length(by_data_vars) + 1L
-    tv_label_col <- str_c("rowlabel", tv_label_idx)
-    if (tv_label_col %in% names(wide)) {
-      tv_vals <- wide[[tv_label_col]]
-      if (method == "bycount") {
-        # For count-based, use the pre-computed ord1 from cast_to_wide
-        # (which is seq_len(.N) based on dcast order)
-        # We need to sum counts across columns for ordering
-        # Use ord1 as-is (already reflects the dcast order which respects .sort_key)
-        # No override needed for bycount — handle via pre-sort below
-      } else {
-        wide[, ord1 := compute_var_order(
-          tv_vals, var_name = tv, data_dt = dt, method = method
-        )]
-      }
-    }
   }
 
   # --- Merge risk difference columns onto wide result ---
@@ -404,7 +390,8 @@ build_count_layer_nested <- function(dt, target_vars, cols, by_data_vars, by_lab
   }
 
   # Sort for correct interleaving: outer value, then level, then inner value
-  sort_nested(combined, target_vars, by_data_vars, dt = dt)
+  sort_nested(combined, target_vars, by_data_vars, dt = dt,
+              outer_sort_position = settings$outer_sort_position)
 
   # --- Pairwise per-level association test (#49) ---
   # Computed on the category rows (all nesting levels) before the special rows
@@ -649,7 +636,8 @@ build_nested_row_labels_special <- function(dt, by_labels, by_data_vars,
 
 #' Sort nested count data for correct interleaving
 #' @keywords internal
-sort_nested <- function(combined, target_vars, by_data_vars, dt = NULL) {
+sort_nested <- function(combined, target_vars, by_data_vars, dt = NULL,
+                        outer_sort_position = NULL) {
   n_levels <- length(target_vars)
 
   # Compute sort keys for each level. Coerce to character so the source factor
@@ -660,6 +648,12 @@ sort_nested <- function(combined, target_vars, by_data_vars, dt = NULL) {
   combined[, .sort_outer := compute_var_order(
     as.character(get(target_vars[1])), var_name = target_vars[1], data_dt = dt
   )]
+
+  # outer_sort_position = "desc" reverses the outer-level ordering while keeping
+  # the inner order (and the subtotal-before-detail nesting) intact (issue #57).
+  if (identical(outer_sort_position, "desc")) {
+    combined[, .sort_outer := -.sort_outer]
+  }
 
   if (n_levels >= 2) {
     # Inner rank: same priority, applied to the inner target var. A global key

--- a/R/ordering.R
+++ b/R/ordering.R
@@ -98,18 +98,29 @@ compute_count_sort_keys <- function(counts, dt, cols, by_data_vars, tv, settings
 
   # Sort key for target variable
   if (!is.null(method) && method == "bycount") {
-    # Count-based ordering: use the count value from a specific column level
-    if (!is.null(ordering_cols_setting) && result_order_var %in% names(counts)) {
-      # Filter to the specified column level and get counts
-      count_vals <- counts[[result_order_var]]
-      counts[, .ord_tv := compute_var_order(
-        get(tv), method = "bycount", count_values = count_vals
-      )]
+    # Count-based ordering. The sort key must be constant across the column
+    # (cols) dimension for a given target value, so aggregate the ordering
+    # statistic per (by-group, target) rather than using the per-column count.
+    # `result_order_var` picks the statistic (default "n"); `ordering_cols`
+    # restricts the tally to a specific column level (issue #57).
+    order_var <- if (result_order_var %in% names(counts)) result_order_var else "n"
+    agg_src <- if (".is_special" %in% names(counts)) {
+      counts[.is_special == 0]
     } else {
-      counts[, .ord_tv := compute_var_order(
-        get(tv), method = "bycount", count_values = counts[["n"]]
-      )]
+      counts
     }
+    if (!is.null(ordering_cols_setting) && length(cols) >= 1 &&
+        cols[1] %in% names(counts)) {
+      agg_src <- agg_src[as.character(get(cols[1])) %in%
+                           as.character(ordering_cols_setting)]
+    }
+    key_vars <- c(by_data_vars, tv)
+    agg <- agg_src[, list(.agg_cnt = sum(get(order_var), na.rm = TRUE)),
+                   by = key_vars]
+    counts[agg, .agg_cnt := i..agg_cnt, on = key_vars]
+    counts[is.na(.agg_cnt), .agg_cnt := 0]
+    counts[, .ord_tv := -.agg_cnt]   # descending count -> ascending sort key
+    counts[, .agg_cnt := NULL]
   } else {
     counts[, .ord_tv := compute_var_order(
       get(tv), var_name = tv, data_dt = dt, method = method

--- a/R/tplyr2-package.R
+++ b/R/tplyr2-package.R
@@ -7,11 +7,12 @@ NULL
 
 # Suppress R CMD check NOTEs for data.table column references
 utils::globalVariables(c(
-  ".", ".col_combo", ".comp_idx", ".disp", ".idx", ".join_key", ".missing_sort",
+  ".", ".agg_cnt", ".col_combo", ".comp_idx", ".disp", ".idx", ".is_special",
+  ".join_key", ".missing_sort",
   ".nest_level", ".ord_tv", ".row_order", ".sort_inner", ".sort_key",
   ".sort_outer", ".total_sort", ".tplyr_synthetic", ".var_name",
   "analysis_id", "distinct_n", "distinct_pct", "distinct_total",
-  "formatted", "formatted_rd", "i..sort_inner", "i.formatted_rd",
+  "formatted", "formatted_rd", "i..agg_cnt", "i..sort_inner", "i.formatted_rd",
   "id", "max_dec", "max_int", "median", "n", "og_row", "ord1",
   "ordindx", "out", "pct", "pop_n", "row_label", "rowlabel1",
   "rowlabel2", "s", "sd", "stat_order", "stub_sort", "target_n",

--- a/R/validate.R
+++ b/R/validate.R
@@ -130,6 +130,13 @@ validate_layer <- function(layer, index, cols = NULL) {
                   "\"full\", \"count_only\", or \"blank\""),
          call. = FALSE)
   }
+  osp <- layer$settings$outer_sort_position
+  if (!is.null(osp) && (!is.character(osp) || length(osp) != 1 ||
+                        !osp %in% c("asc", "desc"))) {
+    stop(str_glue("Layer {index}: outer_sort_position must be ",
+                  "\"asc\" or \"desc\""),
+         call. = FALSE)
+  }
 
   if (!is.null(layer$settings$assoc_test) &&
       !inherits(layer$settings$assoc_test, "tplyr_assoc_test")) {

--- a/man/sort_nested.Rd
+++ b/man/sort_nested.Rd
@@ -4,7 +4,13 @@
 \alias{sort_nested}
 \title{Sort nested count data for correct interleaving}
 \usage{
-sort_nested(combined, target_vars, by_data_vars, dt = NULL)
+sort_nested(
+  combined,
+  target_vars,
+  by_data_vars,
+  dt = NULL,
+  outer_sort_position = NULL
+)
 }
 \description{
 Sort nested count data for correct interleaving

--- a/tests/testthat/test-ordering.R
+++ b/tests/testthat/test-ordering.R
@@ -260,3 +260,93 @@ test_that("count by-group order falls back to alphabetical for non-factor", {
   b <- b[order(b$ord_layer_1), ]
   expect_equal(unique(b$rowlabel1), c("alpha", "mid", "zeta"))
 })
+
+# --- order_count_method = "bycount" and companions (#57) ---
+
+.bycount_data <- function() {
+  # totals across arms: Apple=24, Zebra=23, Mango=13
+  # col A: Zebra=20, Apple=6, Mango=4 ; col B: Apple=18, Mango=9, Zebra=3
+  data.frame(
+    TRT = factor(rep(c("A", "B"), each = 30), levels = c("A", "B")),
+    AE  = factor(c(rep("Zebra", 20), rep("Apple", 6), rep("Mango", 4),
+                   rep("Apple", 18), rep("Mango", 9), rep("Zebra", 3)),
+                 levels = c("Apple", "Mango", "Zebra")),
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("order_count_method = 'bycount' sorts by descending total count (#57)", {
+  d <- .bycount_data()
+  b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_count("AE", settings = layer_settings(order_count_method = "bycount")))), d)
+  b <- b[order(b$ord_layer_1), ]
+  expect_equal(b$rowlabel1, c("Apple", "Zebra", "Mango"))
+})
+
+test_that("bycount keeps the total row last (#57)", {
+  d <- .bycount_data()
+  b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_count("AE", settings = layer_settings(
+      order_count_method = "bycount", total_row = TRUE)))), d)
+  b <- b[order(b$ord_layer_1), ]
+  expect_equal(b$rowlabel1[nrow(b)], "Total")
+  expect_equal(b$rowlabel1[1:3], c("Apple", "Zebra", "Mango"))
+})
+
+test_that("ordering_cols sorts bycount by a specific column's count (#57)", {
+  d <- .bycount_data()
+  ord <- function(oc) {
+    b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+      group_count("AE", settings = layer_settings(
+        order_count_method = "bycount", ordering_cols = oc)))), d)
+    b[order(b$ord_layer_1), ]$rowlabel1
+  }
+  expect_equal(ord("A"), c("Zebra", "Apple", "Mango"))   # col A: 20,6,4
+  expect_equal(ord("B"), c("Apple", "Mango", "Zebra"))   # col B: 18,9,3
+})
+
+test_that("bycount blocks by-groups instead of interleaving them (#57)", {
+  d <- .bycount_data()
+  d$GRP <- factor(rep(c("G1", "G2"), 30), levels = c("G1", "G2"))
+  b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_count("AE", by = "GRP", settings = layer_settings(
+      order_count_method = "byfactor")))), d)
+  b <- b[order(b$ord_layer_1), ]
+  # every G1 row comes before every G2 row (blocked, not interleaved)
+  expect_true(max(which(b$rowlabel1 == "G1")) < min(which(b$rowlabel1 == "G2")))
+})
+
+test_that("the default ordering respects target factor levels (#57)", {
+  d <- data.frame(
+    TRT = factor(rep("A", 30)),
+    AE  = factor(rep(c("Zebra", "Apple", "Mango"), 10),
+                 levels = c("Zebra", "Apple", "Mango")))
+  b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_count("AE"))), d)   # no order_count_method -> default
+  b <- b[order(b$ord_layer_1), ]
+  expect_equal(b$rowlabel1, c("Zebra", "Apple", "Mango"))  # factor order, not alphabetical
+})
+
+test_that("outer_sort_position = 'desc' reverses nested outer ordering (#57)", {
+  d <- data.frame(
+    TRT = factor(rep("A", 40)),
+    SOC = factor(rep(c("Alpha", "Beta", "Gamma"), c(16, 14, 10)),
+                 levels = c("Alpha", "Beta", "Gamma")),
+    PT  = factor(rep(c("p1", "p2"), 20)))
+  outer_order <- function(osp) {
+    b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+      group_count(c("SOC", "PT"), settings = layer_settings(
+        outer_sort_position = osp)))), d)
+    b <- b[order(b$ord_layer_1), ]
+    unique(b$rowlabel1)
+  }
+  expect_equal(outer_order("asc"),  c("Alpha", "Beta", "Gamma"))
+  expect_equal(outer_order("desc"), c("Gamma", "Beta", "Alpha"))
+  # invalid value errors
+  expect_error(
+    tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+      group_count(c("SOC", "PT"), settings = layer_settings(
+        outer_sort_position = "sideways")))), d),
+    "outer_sort_position must be"
+  )
+})


### PR DESCRIPTION
Closes #57.

Three count-layer sort settings were accepted but silently ignored, and any explicit `order_count_method` interleaved `by`-groups. All fixed.

## `order_count_method = "bycount"` now sorts by count

Its sort key was computed per (column × by × target) — varying across the cast's column dimension — so it couldn't drive the row order and `bycount` fell back to the default (alphabetical/factor) order. `compute_count_sort_keys()` now **aggregates** the ordering statistic per (by, target) into a key that's constant per output row, honoring:
- `result_order_var` — which statistic to tally (default `"n"`);
- `ordering_cols` — which column level supplies the count (previously never used to filter).

```
totals: Apple=24, Zebra=23, Mango=13  ->  bycount: Apple, Zebra, Mango   (was Apple, Mango, Zebra)
```

## By-groups no longer interleave; default respects factor levels

The per-target key is now threaded through the **dcast LHS** (between the by-group keys and the row labels) instead of a post-cast `ord1` override. That override discarded by-group blocking, so any explicit method interleaved groups (`G1 Zebra, G2 Zebra, G1 Apple, …`). Routing the key through the cast keeps by-groups **blocked** and special (total/missing) rows **last** for every method. A welcome side effect: the **default** ordering now respects the target's factor levels rather than ordering it alphabetically.

## `outer_sort_position = "desc"` reverses a nested layer's outer level

Previously never read; now wired into `sort_nested()` and validated as `"asc"`/`"desc"`.

## Tests / docs

- New ordering tests: bycount by total and by a specific column, by-group blocking, factor-level default, total-row placement, and nested outer reversal (+ invalid-value error). Full suite green (**1320 passing**), no regressions — including no fallout from the default now honoring factor levels.
- `NEWS.md` bug-fix bullet.

## Coordination note (vignette)

PR #59 (the vignette overhaul) revised `sort.Rmd` to describe these settings as *not honored* and to show a post-processing workaround. Once both this and #59 land, that section is stale and should be flipped to document the now-working settings. No git conflict (this PR is code-only; #59 is vignettes-only) — it's a content follow-up I'll make after both merge (or fold into whichever merges second).

🤖 Generated with [Claude Code](https://claude.com/claude-code)