### PR TITLE
Honor order_count_method = "bycount" on the inner level of nested count layers (#64)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -136,6 +136,13 @@
   even when it was a factor). The target sort key is threaded through the cast
   so all methods compose correctly with by-groups and special (total/missing)
   rows.
+- `order_count_method = "bycount"` now also reaches the **inner** level of a
+  nested count layer (#64), sorting (e.g.) preferred terms by descending count
+  within each system organ class -- the AE-by-SOC/PT convention -- with
+  `result_order_var`/`ordering_cols` honored. Previously it only affected
+  single-level layers. The outer level keeps its own order (controlled by
+  `outer_sort_position`), so the useful "outer alphabetical, inner by descending
+  count" layout comes for free.
 - `risk_diff` on a **nested** count layer now errors instead of silently
   emitting an all-blank column (#58). Risk difference is computed only on
   single-level count layers; on a nested SOC/PT layer the setting previously

--- a/R/build_count.R
+++ b/R/build_count.R
@@ -391,7 +391,11 @@ build_count_layer_nested <- function(dt, target_vars, cols, by_data_vars, by_lab
 
   # Sort for correct interleaving: outer value, then level, then inner value
   sort_nested(combined, target_vars, by_data_vars, dt = dt,
-              outer_sort_position = settings$outer_sort_position)
+              outer_sort_position = settings$outer_sort_position,
+              order_count_method = settings$order_count_method,
+              result_order_var = settings$result_order_var %||% "n",
+              ordering_cols = settings$ordering_cols,
+              cols = cols)
 
   # --- Pairwise per-level association test (#49) ---
   # Computed on the category rows (all nesting levels) before the special rows
@@ -637,7 +641,9 @@ build_nested_row_labels_special <- function(dt, by_labels, by_data_vars,
 #' Sort nested count data for correct interleaving
 #' @keywords internal
 sort_nested <- function(combined, target_vars, by_data_vars, dt = NULL,
-                        outer_sort_position = NULL) {
+                        outer_sort_position = NULL, order_count_method = NULL,
+                        result_order_var = "n", ordering_cols = NULL,
+                        cols = character(0)) {
   n_levels <- length(target_vars)
 
   # Compute sort keys for each level. Coerce to character so the source factor
@@ -656,15 +662,37 @@ sort_nested <- function(combined, target_vars, by_data_vars, dt = NULL,
   }
 
   if (n_levels >= 2) {
-    # Inner rank: same priority, applied to the inner target var. A global key
-    # orders inner values consistently across outer groups; combined with the
-    # outer/nest_level sort below it interleaves correctly.
+    # Inner rank, applied to the inner target var. By default a factor/VARN/
+    # alphabetical key orders inner values consistently across outer groups.
+    # With order_count_method = "bycount" the inner level is instead sorted by
+    # descending count *within each outer group* (issue #64) -- the AE-by-SOC/PT
+    # convention -- while the outer level keeps its own order (outer_sort_position
+    # above). Either way the outer/nest_level sort keeps groups blocked.
     combined[, .sort_inner := 0L]
     inner_rows <- combined[.nest_level >= 2]
     if (nrow(inner_rows) > 0) {
-      inner_rows[, .sort_inner := compute_var_order(
-        as.character(get(target_vars[2])), var_name = target_vars[2], data_dt = dt
-      )]
+      if (identical(order_count_method, "bycount")) {
+        order_var <- if (result_order_var %in% names(inner_rows)) {
+          result_order_var
+        } else {
+          "n"
+        }
+        agg_src <- inner_rows
+        if (!is.null(ordering_cols) && length(cols) >= 1 &&
+            cols[1] %in% names(agg_src)) {
+          agg_src <- agg_src[as.character(get(cols[1])) %in%
+                               as.character(ordering_cols)]
+        }
+        keyv <- c(by_data_vars, target_vars[1], target_vars[2])
+        agg <- agg_src[, list(.ic = sum(get(order_var), na.rm = TRUE)),
+                       by = keyv]
+        inner_rows[, .sort_inner := 0]
+        inner_rows[agg, .sort_inner := -i..ic, on = keyv]  # descending count
+      } else {
+        inner_rows[, .sort_inner := compute_var_order(
+          as.character(get(target_vars[2])), var_name = target_vars[2], data_dt = dt
+        )]
+      }
       # Update combined via join
       join_cols <- intersect(names(combined), names(inner_rows))
       join_cols <- setdiff(join_cols, ".sort_inner")

--- a/R/tplyr2-package.R
+++ b/R/tplyr2-package.R
@@ -9,10 +9,10 @@ NULL
 utils::globalVariables(c(
   ".", ".agg_cnt", ".col_combo", ".comp_idx", ".disp", ".idx", ".is_special",
   ".join_key", ".missing_sort",
-  ".nest_level", ".ord_tv", ".row_order", ".sort_inner", ".sort_key",
+  ".ic", ".nest_level", ".ord_tv", ".row_order", ".sort_inner", ".sort_key",
   ".sort_outer", ".total_sort", ".tplyr_synthetic", ".var_name",
   "analysis_id", "distinct_n", "distinct_pct", "distinct_total",
-  "formatted", "formatted_rd", "i..agg_cnt", "i..sort_inner", "i.formatted_rd",
+  "formatted", "formatted_rd", "i..agg_cnt", "i..ic", "i..sort_inner", "i.formatted_rd",
   "id", "max_dec", "max_int", "median", "n", "og_row", "ord1",
   "ordindx", "out", "pct", "pop_n", "row_label", "rowlabel1",
   "rowlabel2", "s", "sd", "stat_order", "stub_sort", "target_n",

--- a/man/sort_nested.Rd
+++ b/man/sort_nested.Rd
@@ -9,7 +9,11 @@ sort_nested(
   target_vars,
   by_data_vars,
   dt = NULL,
-  outer_sort_position = NULL
+  outer_sort_position = NULL,
+  order_count_method = NULL,
+  result_order_var = "n",
+  ordering_cols = NULL,
+  cols = character(0)
 )
 }
 \description{

--- a/tests/testthat/test-ordering.R
+++ b/tests/testthat/test-ordering.R
@@ -350,3 +350,54 @@ test_that("outer_sort_position = 'desc' reverses nested outer ordering (#57)", {
     "outer_sort_position must be"
   )
 })
+
+# --- bycount on the inner level of a nested count layer (#64) ---
+
+.nested_bycount_data <- function() {
+  # SOC1: p1=5, p2=2 ; SOC2: q1=1, q2=4  (distinct subjects)
+  mk <- function(soc, pt, n) do.call(rbind, Map(
+    function(p, k) data.frame(SOC = soc, PT = p,
+                              USUBJID = paste0(soc, p, seq_len(k)),
+                              stringsAsFactors = FALSE), pt, n))
+  d <- rbind(mk("SOC1", c("p1", "p2"), c(5, 2)),
+             mk("SOC2", c("q1", "q2"), c(1, 4)))
+  d$TRT <- factor("High", levels = "High")
+  d
+}
+
+.nested_order <- function(d, ...) {
+  b <- tplyr_build(tplyr_spec(cols = "TRT", layers = tplyr_layers(
+    group_count(c("SOC", "PT"), settings = layer_settings(
+      distinct_by = "USUBJID",
+      format_strings = list(n_counts = f_str("xx", "distinct_n")), ...)))), d)
+  b <- b[order(b$ord_layer_1), ]
+  sprintf("%s/%s", trimws(b$rowlabel1), trimws(b$rowlabel2))
+}
+
+test_that("bycount sorts the inner level by descending count within each outer group (#64)", {
+  d <- .nested_bycount_data()
+  ord <- .nested_order(d, order_count_method = "bycount")
+  # SOC1 subtotal, then p1(5) before p2(2); SOC2 subtotal, then q2(4) before q1(1)
+  expect_equal(ord, c("SOC1/", "SOC1/p1", "SOC1/p2",
+                      "SOC2/", "SOC2/q2", "SOC2/q1"))
+})
+
+test_that("nested bycount leaves the outer level in its default (factor) order (#64)", {
+  d <- .nested_bycount_data()
+  # SOC2 has more total subjects (5) than SOC1 (7? no: SOC1=7) -- regardless,
+  # outer stays alphabetical SOC1 then SOC2, not reordered by count
+  ord <- .nested_order(d, order_count_method = "bycount")
+  outer <- unique(sub("/.*$", "", ord))
+  expect_equal(outer, c("SOC1", "SOC2"))
+})
+
+test_that("nested bycount honors result_order_var and composes with outer_sort_position (#64)", {
+  d <- .nested_bycount_data()
+  # result_order_var = distinct_n (same as n here) still sorts inner by count
+  ord <- .nested_order(d, order_count_method = "bycount",
+                       result_order_var = "distinct_n",
+                       outer_sort_position = "desc")
+  # outer reversed (SOC2 first), inner still by descending count within each
+  expect_equal(ord, c("SOC2/", "SOC2/q2", "SOC2/q1",
+                      "SOC1/", "SOC1/p1", "SOC1/p2"))
+})


### PR DESCRIPTION
Closes #64.

Follow-on to #57/#63. `order_count_method = "bycount"` sorted single-level count layers, but on a **nested** layer it was ignored on the inner level — preferred terms stayed factor/alphabetical instead of sorting by descending frequency within each system organ class (the AE-by-SOC/PT convention).

## Fix

`sort_nested()` now receives the ordering settings. When `order_count_method = "bycount"`, it ranks the **inner** target by descending count *within each outer group*:
- aggregates `result_order_var` (default `"n"`, e.g. `"distinct_n"` for subject counts) per `(by, outer, inner)`, optionally restricted to `ordering_cols`;
- uses `-count` as the inner sort key, so the existing outer / `.nest_level` sort keeps outer groups **blocked** and subtotals ahead of their detail rows.

The **outer** level keeps its own factor/VARN/alpha order and `outer_sort_position` — so the useful "outer alphabetical, inner by descending count" layout comes for free.

## Behavior (issue reprex + multi-SOC)

```
single bycount:  ccc=6  bbb=3  aaa=1
NESTED bycount:  ONESOC/=10  ONESOC/ccc=6  ONESOC/bbb=3  ONESOC/aaa=1   (was 1,3,6)

multi-SOC:  SOC1/=7  SOC1/p1=5  SOC1/p2=2   SOC2/=5  SOC2/q2=4  SOC2/q1=1
```

## Tests / docs

- New ordering tests: per-outer-group inner ordering, outer level staying in default order, and composition with `result_order_var` + `outer_sort_position`. Full suite green (**1339 passing**).
- `NEWS.md` bug-fix bullet.

## Vignette note

The (open) vignette PR #59 documents nested layers as ordering both levels by factor; once both land I'll fold a one-line update into the sort-vignette reconciliation so the AE example can show `bycount` on the inner level directly. No git conflict (this is code-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)