### PR TITLE
Release prep for 0.2.0: examples on every export, CRAN scaffolding

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^scratch$
 ^pkgdown$
 ^benchmark_comparison\.R$
+^cran-comments\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,9 @@ Description: Implements a grammar of summary data for clinical reports. Clinical
     independent summary block. Supports count, descriptive statistics, and shift
     layer types with a declarative spec-based API built on data.table for performance.
 License: MIT + file LICENSE
+URL: https://github.com/atorus-research/tplyr2,
+    https://atorus-research.github.io/tplyr2/
+BugReports: https://github.com/atorus-research/tplyr2/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,24 @@
 # tplyr2 0.2.0
 
-## Breaking changes
+**First CRAN release.**
+
+tplyr2 builds clinical summary tables from a declarative specification. A
+`tplyr_spec()` describes what to compute — count, descriptive, shift, and
+custom analysis layers, with population-based denominators, formatting, sorting,
+and traceability — and `tplyr_build()` executes it against data. The spec is
+pure configuration, so it can be written, serialized to JSON or YAML, reviewed,
+and re-run independently of any dataset.
+
+tplyr2 is a ground-up successor to the
+[Tplyr](https://cran.r-project.org/package=Tplyr) package rather than a new
+version of it. The two have different APIs and are intended to coexist while
+users migrate; `vignette("migration")` maps one onto the other.
+
+Versions before 0.2.0 were development releases available only from GitHub. The
+sections below record what changed since 0.1.0, and are relevant to anyone who
+installed the package that way.
+
+## Breaking changes since 0.1.0
 
 Several settings that were previously accepted and silently ignored now error.
 Each of these produced a plausible-looking but wrong table, which is the wrong

--- a/R/ard.R
+++ b/R/ard.R
@@ -13,6 +13,25 @@
 #'     \item{stat_value}{Numeric value of the statistic}
 #'     \item{...}{Grouping columns from the original data}
 #'   }
+#'
+#' @examples
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(
+#'     group_count("AGEGR1"),
+#'     group_desc("AGE")
+#'   )
+#' )
+#' built <- tplyr_build(spec, tplyr_adsl)
+#'
+#' ard <- tplyr_to_ard(built)
+#' head(ard)
+#'
+#' # One row per statistic per group; analysis_id identifies the layer
+#' table(ard$analysis_id)
+#' unique(ard$stat_name[ard$analysis_id == 2])
+#'
+#' @seealso [tplyr_from_ard()] to rebuild a formatted table from an ARD.
 #' @export
 tplyr_to_ard <- function(result) {
   nd <- attr(result, "numeric_data")
@@ -100,6 +119,32 @@ tplyr_to_ard <- function(result) {
 #' @param spec A \code{tplyr_spec} object defining the table structure
 #'
 #' @return A data.frame with the same structure as \code{tplyr_build()} output
+#'
+#' @examples
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(group_desc("AGE"))
+#' )
+#' built <- tplyr_build(spec, tplyr_adsl)
+#'
+#' # Round-tripping through the ARD reproduces the formatted cells, so a table
+#' # can be rebuilt from stored results without the subject-level data
+#' ard <- tplyr_to_ard(built)
+#' recon <- tplyr_from_ard(ard, spec)
+#' recon[, c("rowlabel1", "res1")]
+#' identical(as.vector(recon$res1), as.vector(built$res1))
+#'
+#' # Changing only the spec's formats re-renders the same numbers differently
+#' respec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(
+#'     group_desc("AGE", settings = layer_settings(
+#'       format_strings = list("Mean (SD)" = f_str("xx.xx (xx.xxx)", "mean", "sd"))))
+#'   )
+#' )
+#' tplyr_from_ard(ard, respec)[, c("rowlabel1", "res1")]
+#'
+#' @seealso [tplyr_to_ard()] to produce the ARD.
 #' @export
 tplyr_from_ard <- function(ard, spec) {
   if (!inherits(spec, "tplyr_spec")) {

--- a/R/build.R
+++ b/R/build.R
@@ -9,9 +9,40 @@
 #' @param metadata If TRUE, attach cell-level metadata enabling traceability
 #'   back to source data rows via \code{tplyr_meta_result()} and
 #'   \code{tplyr_meta_subset()}.
-#' @param ... Additional named arguments to override spec-level parameters
+#' @param ... Additional named arguments overriding spec-level parameters. Names
+#'   must match a field of `spec` (or `where`/`pop_data`); an unrecognized name
+#'   is an error rather than a silent no-op. Because `...` is evaluated eagerly,
+#'   a `where` override must be a character string or a quoted expression, not
+#'   the bare expression [tplyr_spec()] accepts.
 #'
 #' @return A data.frame with rowlabel, res, and ord columns
+#'
+#' @examples
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(group_count("AGEGR1"))
+#' )
+#' tplyr_build(spec, tplyr_adsl)
+#'
+#' # Override spec fields at build time without editing the spec. Overrides go
+#' # through `...`, which evaluates eagerly, so a `where` must be a string or
+#' # quoted -- not the bare expression tplyr_spec() accepts.
+#' tplyr_build(spec, tplyr_adsl, where = "SEX == 'F'")
+#' tplyr_build(spec, tplyr_adsl, where = quote(SEX == "F"))
+#'
+#' # Population data supplies the denominators and the header N
+#' pop_spec <- tplyr_spec(
+#'   cols = "TRTA",
+#'   pop_data = pop_data(cols = c("TRTA" = "TRT01P")),
+#'   layers = tplyr_layers(
+#'     group_count("AEBODSYS",
+#'                 settings = layer_settings(distinct_by = "USUBJID"))
+#'   )
+#' )
+#' head(tplyr_build(pop_spec, tplyr_adae, pop_data = tplyr_adsl))
+#'
+#' @seealso [tplyr_spec()] to build the specification, and
+#'   [tplyr_numeric_data()] for the unformatted values behind the cells.
 #' @export
 tplyr_build <- function(spec, data, pop_data = NULL, metadata = FALSE, ...) {
   # Custom summaries and assoc_test functions render failures as blank cells;

--- a/R/f_str.R
+++ b/R/f_str.R
@@ -12,6 +12,43 @@
 #'   NA groups as blanks of the field width.
 #'
 #' @return A tplyr_f_str object
+#'
+#' @details
+#' Each run of `x` characters is one format group, and each group is filled by
+#' the correspondingly-positioned variable in `...`. The count of `x`s sets the
+#' field width, so `"xx.x"` renders two integer digits and one decimal. Literal
+#' text between groups is preserved verbatim. `a` (and `A`) request
+#' auto-precision, where the decimal count comes from the data.
+#'
+#' @examples
+#' # Two format groups filled by n and pct
+#' fmt <- f_str("xx (xx.x%)", "n", "pct")
+#' fmt
+#' apply_formats(fmt, n = c(5, 12), pct = c(4.5, 33.33))
+#'
+#' # Width is set by the number of x's
+#' apply_formats(f_str("xxx", "n"), n = 7)
+#' apply_formats(f_str("x", "n"), n = 7)
+#'
+#' # `empty` fills each NA group in place, preserving alignment
+#' apply_formats(f_str("xx (xxx)", "n", "pct", empty = "NA"),
+#'               n = NA, pct = NA)
+#'
+#' # `.overall` replaces the whole cell, but only when every group is NA
+#' both_na <- f_str("xx (xxx)", "n", "pct", empty = c(.overall = "Not est."))
+#' apply_formats(both_na, n = NA, pct = NA)
+#'
+#' # Used in a layer
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(
+#'     group_count("AGEGR1", settings = layer_settings(
+#'       format_strings = list(n_counts = f_str("xx (xx.x%)", "n", "pct"))))
+#'   )
+#' )
+#' tplyr_build(spec, tplyr_adsl)
+#'
+#' @seealso [apply_formats()] to render values outside a build.
 #' @export
 f_str <- function(format_string, ..., empty = NULL) {
   vars <- c(...)
@@ -54,7 +91,8 @@ f_str <- function(format_string, ..., empty = NULL) {
 #' Vectorized formatting function. Takes an f_str object and numeric vectors,
 #' returns a character vector of formatted strings.
 #'
-#' @param fmt An f_str object or character format string
+#' @param fmt An [f_str()] object. A bare character format string is rejected,
+#'   since the variable names are what bind `...` to the format groups.
 #' @param ... Numeric vectors, one per variable in the f_str (positional matching)
 #' @param precision Optional list of resolved precision per group (for auto-precision)
 #' @param lt Optional numeric less-than threshold applied to the group named by
@@ -76,6 +114,26 @@ f_str <- function(format_string, ..., empty = NULL) {
 #'   spaces) or `"left"` (leading spaces).
 #'
 #' @return Character vector of formatted values
+#'
+#' @examples
+#' # Vectorized: one formatted string per element
+#' apply_formats(f_str("xx (xx.x%)", "n", "pct"),
+#'               n = c(5, 12, 103), pct = c(4.5, 33.333, 99.9))
+#'
+#' # `na` replaces the default blank-width fill
+#' apply_formats(f_str("xx.x", "mean"), mean = c(1.2, NA))
+#' apply_formats(f_str("xx.x", "mean"), mean = c(1.2, NA), na = "NE")
+#' apply_formats(f_str("xx.x", "mean"), mean = c(1.2, NA), na = "")
+#'
+#' # lt/gt thresholds, targeting the percent group (index 2)
+#' apply_formats(f_str("xx (xx.x%)", "n", "pct"), n = c(1, 199), pct = c(0.4, 99.7),
+#'               lt = 1, gt = 99, lt_gt_group = 2)
+#'
+#' # Pad to a fixed width for row-binding against other output
+#' apply_formats(f_str("xx.x", "mean"), mean = c(1.2, 10.75), width = 10)
+#' apply_formats(f_str("xx.x", "mean"), mean = c(1.2, 10.75), width = 10, pad = "left")
+#'
+#' @seealso [f_str()] for the format-string grammar.
 #' @export
 apply_formats <- function(fmt, ..., precision = NULL, lt = NULL, gt = NULL,
                           lt_gt_group = NULL, na = NULL, width = NULL,

--- a/R/layer_settings.R
+++ b/R/layer_settings.R
@@ -151,6 +151,57 @@
 #' @param name Character string, layer name for identification
 #'
 #' @return A tplyr_layer_settings object
+#'
+#' @examples
+#' # Formats and special rows on a count layer
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(
+#'     group_count("AGEGR1", settings = layer_settings(
+#'       format_strings = list(n_counts = f_str("xx (xx.x%)", "n", "pct")),
+#'       total_row = TRUE,
+#'       total_row_label = "Total subjects"
+#'     ))
+#'   )
+#' )
+#' tplyr_build(spec, tplyr_adsl)
+#'
+#' # Denominators: percentages within each arm-by-sex cell rather than the arm
+#' denom <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(
+#'     group_count("AGEGR1", by = "SEX",
+#'                 settings = layer_settings(denoms_by = c("TRT01P", "SEX")))
+#'   )
+#' )
+#' tplyr_build(denom, tplyr_adsl)
+#'
+#' # Auto-precision on a desc layer: 'a' takes decimals from the data, and
+#' # precision_cap bounds them.
+#' prec <- tplyr_spec(
+#'   cols = "TRTA",
+#'   layers = tplyr_layers(
+#'     group_desc("AVAL", by = "PARAMCD", settings = layer_settings(
+#'       format_strings = list("Mean (SD)" = f_str("a.a+1 (a.a+2)", "mean", "sd")),
+#'       precision_by = "PARAMCD",
+#'       precision_cap = c(int = 3, dec = 2)
+#'     ))
+#'   )
+#' )
+#' head(tplyr_build(prec, tplyr_adlb))
+#'
+#' # A custom summary adds a statistic the built-ins do not provide
+#' cv <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(
+#'     group_desc("AGE", settings = layer_settings(
+#'       custom_summaries = list(cv = quote(sd(.var) / mean(.var) * 100)),
+#'       format_strings = list("CV%" = f_str("xx.x", "cv"))
+#'     ))
+#'   )
+#' )
+#' tplyr_build(cv, tplyr_adsl)
+#'
 #' @export
 layer_settings <- function(
     format_strings = NULL,

--- a/R/layers.R
+++ b/R/layers.R
@@ -6,6 +6,18 @@
 #' @param x Character string to use as a label
 #'
 #' @return A tplyr_label object
+#'
+#' @examples
+#' # A `by` string that matches no column is already treated as a label, but
+#' # label() is explicit -- and necessary when the text matches a column name.
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(
+#'     group_count("AGEGR1", by = label("Age Group (y)"))
+#'   )
+#' )
+#' head(tplyr_build(spec, tplyr_adsl))
+#'
 #' @export
 label <- function(x) {
   structure(x, class = c("tplyr_label", "character"))
@@ -30,6 +42,34 @@ is_label <- function(x) {
 #' @param settings A layer_settings object
 #'
 #' @return A tplyr_count_layer object
+#'
+#' @examples
+#' # Counts of a categorical variable within each column group
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(group_count("AGEGR1"))
+#' )
+#' tplyr_build(spec, tplyr_adsl)
+#'
+#' # Distinct subject counts with a total row, filtered to serious events
+#' ae <- tplyr_spec(
+#'   cols = "TRTA",
+#'   layers = tplyr_layers(
+#'     group_count("AEBODSYS",
+#'       where = AESER == "Y",
+#'       settings = layer_settings(distinct_by = "USUBJID", total_row = TRUE))
+#'   )
+#' )
+#' head(tplyr_build(ae, tplyr_adae))
+#'
+#' # Two target variables nest: preferred term within body system
+#' nested <- tplyr_spec(
+#'   cols = "TRTA",
+#'   layers = tplyr_layers(group_count(c("AEBODSYS", "AEDECOD")))
+#' )
+#' head(tplyr_build(nested, tplyr_adae))
+#'
+#' @seealso [layer_settings()] for denominators, sorting, and special rows.
 #' @export
 group_count <- function(target_var, by = NULL, where = NULL, settings = layer_settings()) {
   where_expr <- rlang::enexpr(where)
@@ -54,6 +94,36 @@ group_count <- function(target_var, by = NULL, where = NULL, settings = layer_se
 #' @param settings A layer_settings object
 #'
 #' @return A tplyr_desc_layer object
+#'
+#' @examples
+#' # Default summary: n, Mean (SD), Median, Q1/Q3, Min/Max, Missing
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(group_desc("AGE"))
+#' )
+#' tplyr_build(spec, tplyr_adsl)
+#'
+#' # Choose the statistics and their formats
+#' custom <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(
+#'     group_desc("AGE", settings = layer_settings(
+#'       format_strings = list(
+#'         "n"         = f_str("xx", "n"),
+#'         "Mean (SD)" = f_str("xx.x (xx.xx)", "mean", "sd")
+#'       )))
+#'   )
+#' )
+#' tplyr_build(custom, tplyr_adsl)
+#'
+#' # Several target variables in one layer, grouped by visit
+#' multi <- tplyr_spec(
+#'   cols = "TRTA",
+#'   layers = tplyr_layers(group_desc(c("AVAL", "CHG"), by = "AVISIT"))
+#' )
+#' head(tplyr_build(multi, tplyr_adlb))
+#'
+#' @seealso [layer_settings()] for auto-precision and custom summaries.
 #' @export
 group_desc <- function(target_var, by = NULL, where = NULL, settings = layer_settings()) {
   where_expr <- rlang::enexpr(where)
@@ -78,6 +148,27 @@ group_desc <- function(target_var, by = NULL, where = NULL, settings = layer_set
 #' @param settings A layer_settings object
 #'
 #' @return A tplyr_shift_layer object
+#'
+#' @examples
+#' # Baseline (rows) against post-baseline (columns) reference ranges
+#' spec <- tplyr_spec(
+#'   cols = "TRTA",
+#'   layers = tplyr_layers(
+#'     group_shift(c(row = "BNRIND", column = "ANRIND"))
+#'   )
+#' )
+#' head(tplyr_build(spec, tplyr_adlb))
+#'
+#' # Percentages relative to each baseline (column) group rather than the arm
+#' by_col <- tplyr_spec(
+#'   cols = "TRTA",
+#'   layers = tplyr_layers(
+#'     group_shift(c(row = "BNRIND", column = "ANRIND"),
+#'                 settings = layer_settings(shift_denom = "column"))
+#'   )
+#' )
+#' head(tplyr_build(by_col, tplyr_adlb))
+#'
 #' @export
 group_shift <- function(target_var, by = NULL, where = NULL, settings = layer_settings()) {
   # Validate target_var: must be named character vector with "row" and "column"
@@ -138,6 +229,42 @@ group_shift <- function(target_var, by = NULL, where = NULL, settings = layer_se
 #' on a count/shift layer), see \code{\link{assoc_test}}.
 #'
 #' @return A tplyr_analyze_layer object
+#'
+#' @examples
+#' # format_strings mode: the function returns one row of named numbers, and
+#' # each format string becomes an output row.
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(
+#'     group_analyze("AGE",
+#'       analyze_fn = function(.data, .target_var) {
+#'         v <- .data[[.target_var]]
+#'         data.frame(gmean = exp(mean(log(v))), rng = diff(range(v)))
+#'       },
+#'       settings = layer_settings(format_strings = list(
+#'         "Geometric mean" = f_str("xx.xx", "gmean"),
+#'         "Range"          = f_str("xx", "rng")
+#'       )))
+#'   )
+#' )
+#' tplyr_build(spec, tplyr_adsl)
+#'
+#' # Pre-formatted mode: the function supplies row_label and formatted itself.
+#' pre <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(
+#'     group_analyze("AGE",
+#'       analyze_fn = function(.data, .target_var) {
+#'         v <- .data[[.target_var]]
+#'         data.frame(
+#'           row_label = "Median [IQR]",
+#'           formatted = sprintf("%.1f [%.1f]", median(v), IQR(v))
+#'         )
+#'       })
+#'   )
+#' )
+#' tplyr_build(pre, tplyr_adsl)
+#'
 #' @seealso \code{\link{assoc_test}} for cross-column association tests.
 #' @export
 group_analyze <- function(target_var, by = NULL, where = NULL,
@@ -169,6 +296,19 @@ group_analyze <- function(target_var, by = NULL, where = NULL,
 #'   group_shift(), or group_analyze()
 #'
 #' @return A list of tplyr_layer objects
+#'
+#' @examples
+#' # Layers stack in the order given, and may mix types freely
+#' layers <- tplyr_layers(
+#'   group_desc("AGE"),
+#'   group_count("SEX"),
+#'   group_count("AGEGR1")
+#' )
+#' length(layers)
+#'
+#' spec <- tplyr_spec(cols = "TRT01P", layers = layers)
+#' tplyr_build(spec, tplyr_adsl)
+#'
 #' @export
 tplyr_layers <- function(...) {
   layers <- list(...)
@@ -181,6 +321,12 @@ tplyr_layers <- function(...) {
 #' Check if an object is a tplyr_layer
 #' @param x Object to check
 #' @return Logical
+#'
+#' @examples
+#' is_tplyr_layer(group_count("SEX"))
+#' is_tplyr_layer(group_desc("AGE"))
+#' is_tplyr_layer("SEX")
+#'
 #' @export
 is_tplyr_layer <- function(x) {
   inherits(x, "tplyr_layer")

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -15,6 +15,20 @@
 #'   sub-columns of a column group share the same source-data filters)
 #'
 #' @return A tplyr_meta object
+#'
+#' @examples
+#' # Usually obtained from a build rather than constructed by hand
+#' m <- tplyr_meta(
+#'   names = c("TRT01P", "AGEGR1"),
+#'   filters = list(quote(TRT01P == "Placebo"), quote(AGEGR1 == "65-80")),
+#'   layer_index = 1L
+#' )
+#' m
+#'
+#' # The filters are ordinary language objects, so they can be applied directly
+#' subset(tplyr_adsl, TRT01P == "Placebo" & AGEGR1 == "65-80")[1:3, c("USUBJID", "AGEGR1")]
+#'
+#' @seealso [tplyr_meta_result()] to retrieve one from a build.
 #' @export
 tplyr_meta <- function(names = character(0), filters = list(),
                        layer_index = integer(0), anti_join = NULL,
@@ -83,6 +97,21 @@ print.tplyr_meta <- function(x, ...) {
 #' @param result A data.frame produced by \code{tplyr_build()}
 #'
 #' @return Character vector of row IDs (same length as \code{nrow(result)})
+#'
+#' @examples
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(group_count("AGEGR1"))
+#' )
+#' built <- tplyr_build(spec, tplyr_adsl)
+#' generate_row_ids(built)
+#'
+#' # IDs are derived from the row labels, so generate them from an unmodified
+#' # build. tplyr_build(metadata = TRUE) attaches a row_id column that survives
+#' # post-processing, which is the safer route.
+#' with_meta <- tplyr_build(spec, tplyr_adsl, metadata = TRUE)
+#' with_meta$row_id
+#'
 #' @export
 generate_row_ids <- function(result) {
   rowlabel_cols <- sort(str_subset(names(result), "^rowlabel\\d+$"))
@@ -124,6 +153,19 @@ generate_row_ids <- function(result) {
 #' @param column Character column name (e.g., \code{"res1"})
 #'
 #' @return A \code{tplyr_meta} object, or NULL if no metadata for that cell
+#'
+#' @examples
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(group_count("AGEGR1"))
+#' )
+#' built <- tplyr_build(spec, tplyr_adsl, metadata = TRUE)
+#' built[, c("row_id", "rowlabel1", "res1")]
+#'
+#' # The filters behind the Placebo / 65-80 cell
+#' tplyr_meta_result(built, built$row_id[1], "res1")
+#'
+#' @seealso [tplyr_meta_subset()] to fetch the source rows themselves.
 #' @export
 tplyr_meta_result <- function(result, row_id, column) {
   meta <- attr(result, "tplyr_meta")
@@ -148,6 +190,23 @@ tplyr_meta_result <- function(result, row_id, column) {
 #'   represents a missing subjects row (anti-join)
 #'
 #' @return A data.frame subset of the original data, or NULL if no metadata
+#'
+#' @examples
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(group_count("AGEGR1"))
+#' )
+#' built <- tplyr_build(spec, tplyr_adsl, metadata = TRUE)
+#' built[, c("row_id", "rowlabel1", "res1")]
+#'
+#' # Trace the first cell back to the subjects it counted
+#' src <- tplyr_meta_subset(built, built$row_id[1], "res1", tplyr_adsl)
+#' nrow(src)
+#' head(src[, c("USUBJID", "TRT01P", "AGEGR1")])
+#'
+#' # The row count matches the number displayed in the cell
+#' built$res1[1]
+#'
 #' @export
 tplyr_meta_subset <- function(result, row_id, column, data, pop_data = NULL) {
   meta_obj <- tplyr_meta_result(result, row_id, column)

--- a/R/numeric_data.R
+++ b/R/numeric_data.R
@@ -9,6 +9,28 @@
 #' @return If \code{layer} is specified, a data.frame of raw statistics for that
 #'   layer. If \code{layer} is NULL, a named list of data.frames keyed by layer
 #'   index. Returns NULL if numeric data was not retained.
+#'
+#' @examples
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(
+#'     group_count("AGEGR1"),
+#'     group_desc("AGE")
+#'   )
+#' )
+#' built <- tplyr_build(spec, tplyr_adsl)
+#'
+#' # One data.frame per layer, keyed by layer index
+#' names(tplyr_numeric_data(built))
+#'
+#' # The counts behind the formatted cells, before rounding and padding
+#' head(tplyr_numeric_data(built, 1))
+#'
+#' # Every statistic the desc layer computed, including unused ones
+#' names(tplyr_numeric_data(built, 2))
+#'
+#' @seealso [tplyr_stats_data()] for a single statistic with its grouping
+#'   columns.
 #' @export
 tplyr_numeric_data <- function(result, layer = NULL) {
   nd <- attr(result, "numeric_data")

--- a/R/options.R
+++ b/R/options.R
@@ -25,6 +25,29 @@
 #'     to prevent scientific notation. Default: \code{9999}.}
 #' }
 #'
+#' An unrecognized option name is an error rather than a silent no-op, so a
+#' misspelling cannot quietly leave the build on the default behavior.
+#'
+#' @examples
+#' # Inspect the current values
+#' tplyr2_options()
+#'
+#' # Setting returns the previous values, so the change can be undone
+#' old <- tplyr2_options(IBMRounding = TRUE)
+#' getOption("tplyr2.IBMRounding")
+#' do.call(options, old)
+#' getOption("tplyr2.IBMRounding")
+#'
+#' # IBM (half-away-from-zero) rounding vs R's banker's rounding
+#' fmt <- f_str("xx", "n")
+#' apply_formats(fmt, n = 2.5)
+#' old <- tplyr2_options(IBMRounding = TRUE)
+#' apply_formats(fmt, n = 2.5)
+#' do.call(options, old)
+#'
+#' # A misspelled name errors instead of setting a dead option
+#' try(tplyr2_options(IBMrounding = TRUE))
+#'
 #' @export
 tplyr2_options <- function(...) {
   defaults <- list(
@@ -78,6 +101,15 @@ tplyr2_options <- function(...) {
 #'
 #' @return Named character vector where names are column names and values are
 #'   labels. Columns without labels return \code{NA_character_}.
+#'
+#' @examples
+#' # CDISC data imported via haven carries a "label" attribute per column
+#' labs <- get_data_labels(tplyr_adsl)
+#' head(labs)
+#'
+#' # Columns with no label attribute come back NA
+#' get_data_labels(data.frame(a = 1, b = 2))
+#'
 #' @export
 get_data_labels <- function(data) {
   if (!is.data.frame(data)) stop("data must be a data.frame")

--- a/R/pop_data.R
+++ b/R/pop_data.R
@@ -11,6 +11,28 @@
 #' @param where Expression for filtering the population data (optional)
 #'
 #' @return A tplyr_pop_data object
+#'
+#' @examples
+#' # The AE data's TRTA maps to the subject-level TRT01P. Denominators and the
+#' # header N then come from the population, not from the AE records.
+#' spec <- tplyr_spec(
+#'   cols = "TRTA",
+#'   pop_data = pop_data(cols = c("TRTA" = "TRT01P")),
+#'   layers = tplyr_layers(
+#'     group_count("AEBODSYS",
+#'                 settings = layer_settings(distinct_by = "USUBJID"))
+#'   )
+#' )
+#' built <- tplyr_build(spec, tplyr_adae, pop_data = tplyr_adsl)
+#' head(built)
+#'
+#' # Header N reflects the 254 enrolled subjects, not the 200 AE records
+#' tplyr_header_n(built)
+#'
+#' # Restrict the population to the safety set
+#' saf <- pop_data(cols = c("TRTA" = "TRT01P"), where = SAFFL == "Y")
+#' saf
+#'
 #' @export
 pop_data <- function(cols, where = NULL) {
   where_expr <- rlang::enexpr(where)
@@ -28,6 +50,11 @@ pop_data <- function(cols, where = NULL) {
 #'
 #' @param x An object to check
 #' @return Logical
+#'
+#' @examples
+#' is_pop_data(pop_data(cols = "TRT01P"))
+#' is_pop_data("TRT01P")
+#'
 #' @export
 is_pop_data <- function(x) {
   inherits(x, "tplyr_pop_data")
@@ -52,6 +79,24 @@ print.tplyr_pop_data <- function(x, ...) {
 #' @param label Character string for the total group label (default: "Total")
 #'
 #' @return A tplyr_total_group object
+#'
+#' @examples
+#' # Adds a "Total" column spanning every arm, alongside the individual arms
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   total_groups = list(total_group("TRT01P")),
+#'   layers = tplyr_layers(group_count("AGEGR1"))
+#' )
+#' tplyr_build(spec, tplyr_adsl)
+#'
+#' # Rename the total column
+#' all_pts <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   total_groups = list(total_group("TRT01P", label = "All Patients")),
+#'   layers = tplyr_layers(group_count("SEX"))
+#' )
+#' tplyr_build(all_pts, tplyr_adsl)
+#'
 #' @export
 total_group <- function(col_var, label = "Total") {
   structure(
@@ -80,6 +125,27 @@ print.tplyr_total_group <- function(x, ...) {
 #'   Example: `"High Dose" = c("Dose 1", "Dose 2")`
 #'
 #' @return A tplyr_custom_group object
+#'
+#' @examples
+#' # Pool the two dose arms into one "Xanomeline (All)" column, kept alongside
+#' # the arms it is built from
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   custom_groups = list(custom_group(
+#'     "TRT01P",
+#'     "Xanomeline (All)" = c("Xanomeline High Dose", "Xanomeline Low Dose")
+#'   )),
+#'   layers = tplyr_layers(group_count("AGEGR1"))
+#' )
+#' tplyr_build(spec, tplyr_adsl)
+#'
+#' # Several groups at once
+#' custom_group(
+#'   "TRT01P",
+#'   "Active"  = c("Xanomeline High Dose", "Xanomeline Low Dose"),
+#'   "Control" = "Placebo"
+#' )
+#'
 #' @export
 custom_group <- function(col_var, ...) {
   groups <- list(...)
@@ -110,6 +176,23 @@ print.tplyr_custom_group <- function(x, ...) {
 #'
 #' @return A data.frame with column variable levels and their N values,
 #'   or NULL if no population data was used.
+#'
+#' @examples
+#' spec <- tplyr_spec(
+#'   cols = "TRTA",
+#'   pop_data = pop_data(cols = c("TRTA" = "TRT01P")),
+#'   layers = tplyr_layers(group_count("AEBODSYS"))
+#' )
+#' built <- tplyr_build(spec, tplyr_adae, pop_data = tplyr_adsl)
+#' tplyr_header_n(built)
+#'
+#' # NULL when the build had no population data to draw an N from
+#' no_pop <- tplyr_build(
+#'   tplyr_spec(cols = "TRT01P", layers = tplyr_layers(group_count("SEX"))),
+#'   tplyr_adsl
+#' )
+#' tplyr_header_n(no_pop)
+#'
 #' @export
 tplyr_header_n <- function(result) {
   attr(result, "header_n")

--- a/R/post_process.R
+++ b/R/post_process.R
@@ -8,6 +8,28 @@
 #' @param row_breaks Logical. If TRUE, insert a blank row between layers.
 #'
 #' @return A data.frame with repeated labels blanked
+#'
+#' @examples
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(group_count("AGEGR1", by = "SEX"))
+#' )
+#' built <- tplyr_build(spec, tplyr_adsl)
+#'
+#' # SEX repeats on every age-group row
+#' built[, c("rowlabel1", "rowlabel2")]
+#'
+#' # Masked: each value prints once, at the top of its block
+#' apply_row_masks(built)[, c("rowlabel1", "rowlabel2")]
+#'
+#' # row_breaks inserts a blank row between layers
+#' two <- tplyr_build(
+#'   tplyr_spec(cols = "TRT01P",
+#'              layers = tplyr_layers(group_count("SEX"), group_count("AGEGR1"))),
+#'   tplyr_adsl
+#' )
+#' apply_row_masks(two, row_breaks = TRUE)[, c("rowlabel1", "res1")]
+#'
 #' @export
 apply_row_masks <- function(result, row_breaks = FALSE) {
   if (!is.data.frame(result) || nrow(result) == 0) return(result)
@@ -493,6 +515,24 @@ validate_conditional_format_params <- function(string, format_group, condition, 
 #' @param index Integer, which numeric value to extract (1-based)
 #'
 #' @return Numeric vector
+#'
+#' @examples
+#' cells <- c(" 22 (25.6%)", "  9 (10.5%)", " 55 (64.0%)")
+#'
+#' # Default pulls the count; index = 2 pulls the percent
+#' str_extract_num(cells)
+#' str_extract_num(cells, index = 2)
+#'
+#' # Asking past the available numbers gives NA, as does an NA input
+#' str_extract_num(c(" 5", NA), index = 2)
+#'
+#' # Recover a sort key from an already-formatted table
+#' built <- tplyr_build(
+#'   tplyr_spec(cols = "TRT01P", layers = tplyr_layers(group_count("AGEGR1"))),
+#'   tplyr_adsl
+#' )
+#' built[order(-str_extract_num(built$res1)), c("rowlabel1", "res1")]
+#'
 #' @export
 str_extract_num <- function(x, index = 1L) {
   map_dbl(x, function(s) {
@@ -511,6 +551,16 @@ str_extract_num <- function(x, index = 1L) {
 #' @param replace_with Replacement string for each leading space
 #'
 #' @return Character vector with leading spaces replaced
+#'
+#' @examples
+#' # Indentation survives an HTML renderer that would collapse plain spaces
+#' terms <- c("CARDIAC DISORDERS", "   ATRIAL FIBRILLATION")
+#' out <- replace_leading_whitespace(terms)
+#' out
+#'
+#' # One replacement per leading space; interior spacing is untouched
+#' replace_leading_whitespace("  A B", replace_with = "-")
+#'
 #' @export
 replace_leading_whitespace <- function(x, replace_with = "\u00a0") {
   map_chr(x, function(s) {

--- a/R/serialize.R
+++ b/R/serialize.R
@@ -11,6 +11,32 @@
 #' @param path File path. Extension determines format.
 #'
 #' @return Invisible file path
+#'
+#' @examples
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   where = SAFFL == "Y",
+#'   layers = tplyr_layers(
+#'     group_count("AGEGR1", by = "SEX", settings = layer_settings(
+#'       denoms_by = c("TRT01P", "SEX"),
+#'       format_strings = list(n_counts = f_str("xx (xx.x%)", "n", "pct"))))
+#'   )
+#' )
+#'
+#' path <- file.path(tempdir(), "spec.json")
+#' tplyr_write_spec(spec, path)
+#' cat(readLines(path), sep = "\n")
+#'
+#' # YAML is chosen by the file extension
+#' if (requireNamespace("yaml", quietly = TRUE)) {
+#'   ypath <- file.path(tempdir(), "spec.yaml")
+#'   tplyr_write_spec(spec, ypath)
+#'   cat(readLines(ypath), sep = "\n")
+#'   unlink(ypath)
+#' }
+#' unlink(path)
+#'
+#' @seealso [tplyr_read_spec()] to read one back.
 #' @export
 tplyr_write_spec <- function(spec, path) {
   if (!inherits(spec, "tplyr_spec")) {
@@ -47,6 +73,28 @@ tplyr_write_spec <- function(spec, path) {
 #' @param path File path to a JSON or YAML spec file
 #'
 #' @return A tplyr_spec object
+#'
+#' @examples
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   where = SAFFL == "Y",
+#'   layers = tplyr_layers(group_count("AGEGR1", by = "SEX"))
+#' )
+#'
+#' path <- file.path(tempdir(), "spec.json")
+#' tplyr_write_spec(spec, path)
+#'
+#' # The round trip reproduces the spec, and the same table
+#' spec2 <- tplyr_read_spec(path)
+#' spec2
+#' identical(tplyr_build(spec, tplyr_adsl), tplyr_build(spec2, tplyr_adsl))
+#'
+#' # tplyr_build() also accepts a spec file path directly
+#' head(tplyr_build(path, tplyr_adsl))
+#'
+#' unlink(path)
+#'
+#' @seealso [tplyr_write_spec()] to write one.
 #' @export
 tplyr_read_spec <- function(path) {
   if (!file.exists(path)) {

--- a/R/spec.R
+++ b/R/spec.R
@@ -12,6 +12,30 @@
 #' @param settings Additional spec-level settings (optional)
 #'
 #' @return A tplyr_spec object
+#'
+#' @examples
+#' # A spec is inert configuration -- nothing is computed until tplyr_build()
+#' spec <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   layers = tplyr_layers(
+#'     group_count("AGEGR1"),
+#'     group_desc("AGE")
+#'   )
+#' )
+#' spec
+#'
+#' tplyr_build(spec, tplyr_adsl)
+#'
+#' # A global `where` filter applies to every layer
+#' safety <- tplyr_spec(
+#'   cols = "TRT01P",
+#'   where = SAFFL == "Y",
+#'   layers = tplyr_layers(group_count("SEX"))
+#' )
+#' tplyr_build(safety, tplyr_adsl)
+#'
+#' @seealso [tplyr_build()] to execute a spec, [tplyr_layers()] to assemble
+#'   layers, and [layer_settings()] for per-layer configuration.
 #' @export
 tplyr_spec <- function(
     cols,
@@ -42,6 +66,12 @@ tplyr_spec <- function(
 #'
 #' @param x An object to check
 #' @return Logical
+#'
+#' @examples
+#' spec <- tplyr_spec(cols = "TRT01P", layers = tplyr_layers(group_count("SEX")))
+#' is_tplyr_spec(spec)
+#' is_tplyr_spec(mtcars)
+#'
 #' @export
 is_tplyr_spec <- function(x) {
   inherits(x, "tplyr_spec")

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://github.com/mstackhouse/tplyr2
+url: https://atorus-research.github.io/tplyr2
 
 template:
   bootstrap: 5

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,26 @@
+# cran-comments
+
+## Submission type
+
+This is a new submission.
+
+## Test environments
+
+- local macOS (darwin), R 4.5.x — 0 errors | 0 warnings | 0 notes
+- GitHub Actions:
+  - windows-latest, R release
+  - macOS-latest, R release
+  - ubuntu-22.04, R release and R devel
+  - ubuntu-latest, R release and R devel
+
+## R CMD check results
+
+0 errors | 0 warnings | 0 notes
+
+## Notes for the reviewer
+
+The package name resembles the existing CRAN package `Tplyr`, by the same
+maintainer and organisation. `tplyr2` is a ground-up successor with a different
+(spec-based) API rather than a new version of `Tplyr`; the two are intended to
+coexist on CRAN while users migrate. `vignette("migration")` documents the
+mapping between the two APIs.

--- a/man/apply_formats.Rd
+++ b/man/apply_formats.Rd
@@ -17,7 +17,8 @@ apply_formats(
 )
 }
 \arguments{
-\item{fmt}{An f_str object or character format string}
+\item{fmt}{An \code{\link[=f_str]{f_str()}} object. A bare character format string is rejected,
+since the variable names are what bind \code{...} to the format groups.}
 
 \item{...}{Numeric vectors, one per variable in the f_str (positional matching)}
 
@@ -52,4 +53,26 @@ Character vector of formatted values
 \description{
 Vectorized formatting function. Takes an f_str object and numeric vectors,
 returns a character vector of formatted strings.
+}
+\examples{
+# Vectorized: one formatted string per element
+apply_formats(f_str("xx (xx.x\%)", "n", "pct"),
+              n = c(5, 12, 103), pct = c(4.5, 33.333, 99.9))
+
+# `na` replaces the default blank-width fill
+apply_formats(f_str("xx.x", "mean"), mean = c(1.2, NA))
+apply_formats(f_str("xx.x", "mean"), mean = c(1.2, NA), na = "NE")
+apply_formats(f_str("xx.x", "mean"), mean = c(1.2, NA), na = "")
+
+# lt/gt thresholds, targeting the percent group (index 2)
+apply_formats(f_str("xx (xx.x\%)", "n", "pct"), n = c(1, 199), pct = c(0.4, 99.7),
+              lt = 1, gt = 99, lt_gt_group = 2)
+
+# Pad to a fixed width for row-binding against other output
+apply_formats(f_str("xx.x", "mean"), mean = c(1.2, 10.75), width = 10)
+apply_formats(f_str("xx.x", "mean"), mean = c(1.2, 10.75), width = 10, pad = "left")
+
+}
+\seealso{
+\code{\link[=f_str]{f_str()}} for the format-string grammar.
 }

--- a/man/apply_row_masks.Rd
+++ b/man/apply_row_masks.Rd
@@ -19,3 +19,25 @@ Walks each \code{rowlabel*} column top-to-bottom and blanks values that
 are identical to the previous row, respecting layer boundaries
 (\code{ord_layer_index}).
 }
+\examples{
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(group_count("AGEGR1", by = "SEX"))
+)
+built <- tplyr_build(spec, tplyr_adsl)
+
+# SEX repeats on every age-group row
+built[, c("rowlabel1", "rowlabel2")]
+
+# Masked: each value prints once, at the top of its block
+apply_row_masks(built)[, c("rowlabel1", "rowlabel2")]
+
+# row_breaks inserts a blank row between layers
+two <- tplyr_build(
+  tplyr_spec(cols = "TRT01P",
+             layers = tplyr_layers(group_count("SEX"), group_count("AGEGR1"))),
+  tplyr_adsl
+)
+apply_row_masks(two, row_breaks = TRUE)[, c("rowlabel1", "res1")]
+
+}

--- a/man/custom_group.Rd
+++ b/man/custom_group.Rd
@@ -20,3 +20,24 @@ A tplyr_custom_group object
 Combines existing column levels into a custom group. Rows matching any of
 the source levels are duplicated with the column variable set to the group name.
 }
+\examples{
+# Pool the two dose arms into one "Xanomeline (All)" column, kept alongside
+# the arms it is built from
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  custom_groups = list(custom_group(
+    "TRT01P",
+    "Xanomeline (All)" = c("Xanomeline High Dose", "Xanomeline Low Dose")
+  )),
+  layers = tplyr_layers(group_count("AGEGR1"))
+)
+tplyr_build(spec, tplyr_adsl)
+
+# Several groups at once
+custom_group(
+  "TRT01P",
+  "Active"  = c("Xanomeline High Dose", "Xanomeline Low Dose"),
+  "Control" = "Placebo"
+)
+
+}

--- a/man/f_str.Rd
+++ b/man/f_str.Rd
@@ -26,3 +26,42 @@ A tplyr_f_str object
 \description{
 Create a format string object
 }
+\details{
+Each run of \code{x} characters is one format group, and each group is filled by
+the correspondingly-positioned variable in \code{...}. The count of \code{x}s sets the
+field width, so \code{"xx.x"} renders two integer digits and one decimal. Literal
+text between groups is preserved verbatim. \code{a} (and \code{A}) request
+auto-precision, where the decimal count comes from the data.
+}
+\examples{
+# Two format groups filled by n and pct
+fmt <- f_str("xx (xx.x\%)", "n", "pct")
+fmt
+apply_formats(fmt, n = c(5, 12), pct = c(4.5, 33.33))
+
+# Width is set by the number of x's
+apply_formats(f_str("xxx", "n"), n = 7)
+apply_formats(f_str("x", "n"), n = 7)
+
+# `empty` fills each NA group in place, preserving alignment
+apply_formats(f_str("xx (xxx)", "n", "pct", empty = "NA"),
+              n = NA, pct = NA)
+
+# `.overall` replaces the whole cell, but only when every group is NA
+both_na <- f_str("xx (xxx)", "n", "pct", empty = c(.overall = "Not est."))
+apply_formats(both_na, n = NA, pct = NA)
+
+# Used in a layer
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(
+    group_count("AGEGR1", settings = layer_settings(
+      format_strings = list(n_counts = f_str("xx (xx.x\%)", "n", "pct"))))
+  )
+)
+tplyr_build(spec, tplyr_adsl)
+
+}
+\seealso{
+\code{\link[=apply_formats]{apply_formats()}} to render values outside a build.
+}

--- a/man/generate_row_ids.Rd
+++ b/man/generate_row_ids.Rd
@@ -17,3 +17,18 @@ Creates a character ID for each row by combining the layer index and
 row label values. These IDs can be used with \code{tplyr_meta_result()}
 and \code{tplyr_meta_subset()} to look up cell metadata.
 }
+\examples{
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(group_count("AGEGR1"))
+)
+built <- tplyr_build(spec, tplyr_adsl)
+generate_row_ids(built)
+
+# IDs are derived from the row labels, so generate them from an unmodified
+# build. tplyr_build(metadata = TRUE) attaches a row_id column that survives
+# post-processing, which is the safer route.
+with_meta <- tplyr_build(spec, tplyr_adsl, metadata = TRUE)
+with_meta$row_id
+
+}

--- a/man/get_data_labels.Rd
+++ b/man/get_data_labels.Rd
@@ -18,3 +18,12 @@ Returns a named character vector of variable labels. Labels are extracted
 from the \code{"label"} attribute of each column (standard for Haven-imported
 CDISC data).
 }
+\examples{
+# CDISC data imported via haven carries a "label" attribute per column
+labs <- get_data_labels(tplyr_adsl)
+head(labs)
+
+# Columns with no label attribute come back NA
+get_data_labels(data.frame(a = 1, b = 2))
+
+}

--- a/man/group_analyze.Rd
+++ b/man/group_analyze.Rd
@@ -53,6 +53,42 @@ cannot compute a statistic \emph{across} the treatment columns. For an
 omnibus association test that spans the columns (e.g. Fisher's exact or CMH
 on a count/shift layer), see \code{\link{assoc_test}}.
 }
+\examples{
+# format_strings mode: the function returns one row of named numbers, and
+# each format string becomes an output row.
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(
+    group_analyze("AGE",
+      analyze_fn = function(.data, .target_var) {
+        v <- .data[[.target_var]]
+        data.frame(gmean = exp(mean(log(v))), rng = diff(range(v)))
+      },
+      settings = layer_settings(format_strings = list(
+        "Geometric mean" = f_str("xx.xx", "gmean"),
+        "Range"          = f_str("xx", "rng")
+      )))
+  )
+)
+tplyr_build(spec, tplyr_adsl)
+
+# Pre-formatted mode: the function supplies row_label and formatted itself.
+pre <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(
+    group_analyze("AGE",
+      analyze_fn = function(.data, .target_var) {
+        v <- .data[[.target_var]]
+        data.frame(
+          row_label = "Median [IQR]",
+          formatted = sprintf("\%.1f [\%.1f]", median(v), IQR(v))
+        )
+      })
+  )
+)
+tplyr_build(pre, tplyr_adsl)
+
+}
 \seealso{
 \code{\link{assoc_test}} for cross-column association tests.
 }

--- a/man/group_count.Rd
+++ b/man/group_count.Rd
@@ -24,3 +24,33 @@ A tplyr_count_layer object
 \description{
 Create a count layer
 }
+\examples{
+# Counts of a categorical variable within each column group
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(group_count("AGEGR1"))
+)
+tplyr_build(spec, tplyr_adsl)
+
+# Distinct subject counts with a total row, filtered to serious events
+ae <- tplyr_spec(
+  cols = "TRTA",
+  layers = tplyr_layers(
+    group_count("AEBODSYS",
+      where = AESER == "Y",
+      settings = layer_settings(distinct_by = "USUBJID", total_row = TRUE))
+  )
+)
+head(tplyr_build(ae, tplyr_adae))
+
+# Two target variables nest: preferred term within body system
+nested <- tplyr_spec(
+  cols = "TRTA",
+  layers = tplyr_layers(group_count(c("AEBODSYS", "AEDECOD")))
+)
+head(tplyr_build(nested, tplyr_adae))
+
+}
+\seealso{
+\code{\link[=layer_settings]{layer_settings()}} for denominators, sorting, and special rows.
+}

--- a/man/group_desc.Rd
+++ b/man/group_desc.Rd
@@ -21,3 +21,35 @@ A tplyr_desc_layer object
 \description{
 Create a descriptive statistics layer
 }
+\examples{
+# Default summary: n, Mean (SD), Median, Q1/Q3, Min/Max, Missing
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(group_desc("AGE"))
+)
+tplyr_build(spec, tplyr_adsl)
+
+# Choose the statistics and their formats
+custom <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(
+    group_desc("AGE", settings = layer_settings(
+      format_strings = list(
+        "n"         = f_str("xx", "n"),
+        "Mean (SD)" = f_str("xx.x (xx.xx)", "mean", "sd")
+      )))
+  )
+)
+tplyr_build(custom, tplyr_adsl)
+
+# Several target variables in one layer, grouped by visit
+multi <- tplyr_spec(
+  cols = "TRTA",
+  layers = tplyr_layers(group_desc(c("AVAL", "CHG"), by = "AVISIT"))
+)
+head(tplyr_build(multi, tplyr_adlb))
+
+}
+\seealso{
+\code{\link[=layer_settings]{layer_settings()}} for auto-precision and custom summaries.
+}

--- a/man/group_shift.Rd
+++ b/man/group_shift.Rd
@@ -21,3 +21,24 @@ A tplyr_shift_layer object
 \description{
 Create a shift layer
 }
+\examples{
+# Baseline (rows) against post-baseline (columns) reference ranges
+spec <- tplyr_spec(
+  cols = "TRTA",
+  layers = tplyr_layers(
+    group_shift(c(row = "BNRIND", column = "ANRIND"))
+  )
+)
+head(tplyr_build(spec, tplyr_adlb))
+
+# Percentages relative to each baseline (column) group rather than the arm
+by_col <- tplyr_spec(
+  cols = "TRTA",
+  layers = tplyr_layers(
+    group_shift(c(row = "BNRIND", column = "ANRIND"),
+                settings = layer_settings(shift_denom = "column"))
+  )
+)
+head(tplyr_build(by_col, tplyr_adlb))
+
+}

--- a/man/is_pop_data.Rd
+++ b/man/is_pop_data.Rd
@@ -15,3 +15,8 @@ Logical
 \description{
 Check if an object is a tplyr_pop_data
 }
+\examples{
+is_pop_data(pop_data(cols = "TRT01P"))
+is_pop_data("TRT01P")
+
+}

--- a/man/is_tplyr_layer.Rd
+++ b/man/is_tplyr_layer.Rd
@@ -15,3 +15,9 @@ Logical
 \description{
 Check if an object is a tplyr_layer
 }
+\examples{
+is_tplyr_layer(group_count("SEX"))
+is_tplyr_layer(group_desc("AGE"))
+is_tplyr_layer("SEX")
+
+}

--- a/man/is_tplyr_spec.Rd
+++ b/man/is_tplyr_spec.Rd
@@ -15,3 +15,9 @@ Logical
 \description{
 Check if an object is a tplyr_spec
 }
+\examples{
+spec <- tplyr_spec(cols = "TRT01P", layers = tplyr_layers(group_count("SEX")))
+is_tplyr_spec(spec)
+is_tplyr_spec(mtcars)
+
+}

--- a/man/label.Rd
+++ b/man/label.Rd
@@ -16,3 +16,15 @@ A tplyr_label object
 Explicitly marks a string as a text label (not a data variable name).
 Useful when a label string might coincidentally match a column name.
 }
+\examples{
+# A `by` string that matches no column is already treated as a label, but
+# label() is explicit -- and necessary when the text matches a column name.
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(
+    group_count("AGEGR1", by = label("Age Group (y)"))
+  )
+)
+head(tplyr_build(spec, tplyr_adsl))
+
+}

--- a/man/layer_settings.Rd
+++ b/man/layer_settings.Rd
@@ -235,3 +235,54 @@ settings are applicable for each of the four layer types:\tabular{lllll}{
 Settings provided for an inapplicable layer type are silently ignored.
 }
 
+\examples{
+# Formats and special rows on a count layer
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(
+    group_count("AGEGR1", settings = layer_settings(
+      format_strings = list(n_counts = f_str("xx (xx.x\%)", "n", "pct")),
+      total_row = TRUE,
+      total_row_label = "Total subjects"
+    ))
+  )
+)
+tplyr_build(spec, tplyr_adsl)
+
+# Denominators: percentages within each arm-by-sex cell rather than the arm
+denom <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(
+    group_count("AGEGR1", by = "SEX",
+                settings = layer_settings(denoms_by = c("TRT01P", "SEX")))
+  )
+)
+tplyr_build(denom, tplyr_adsl)
+
+# Auto-precision on a desc layer: 'a' takes decimals from the data, and
+# precision_cap bounds them.
+prec <- tplyr_spec(
+  cols = "TRTA",
+  layers = tplyr_layers(
+    group_desc("AVAL", by = "PARAMCD", settings = layer_settings(
+      format_strings = list("Mean (SD)" = f_str("a.a+1 (a.a+2)", "mean", "sd")),
+      precision_by = "PARAMCD",
+      precision_cap = c(int = 3, dec = 2)
+    ))
+  )
+)
+head(tplyr_build(prec, tplyr_adlb))
+
+# A custom summary adds a statistic the built-ins do not provide
+cv <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(
+    group_desc("AGE", settings = layer_settings(
+      custom_summaries = list(cv = quote(sd(.var) / mean(.var) * 100)),
+      format_strings = list("CV\%" = f_str("xx.x", "cv"))
+    ))
+  )
+)
+tplyr_build(cv, tplyr_adsl)
+
+}

--- a/man/pop_data.Rd
+++ b/man/pop_data.Rd
@@ -22,3 +22,25 @@ Configuration object specifying how population data maps to the spec.
 The actual population data.frame is provided at build time via
 \code{tplyr_build(spec, data, pop_data = ...)}.
 }
+\examples{
+# The AE data's TRTA maps to the subject-level TRT01P. Denominators and the
+# header N then come from the population, not from the AE records.
+spec <- tplyr_spec(
+  cols = "TRTA",
+  pop_data = pop_data(cols = c("TRTA" = "TRT01P")),
+  layers = tplyr_layers(
+    group_count("AEBODSYS",
+                settings = layer_settings(distinct_by = "USUBJID"))
+  )
+)
+built <- tplyr_build(spec, tplyr_adae, pop_data = tplyr_adsl)
+head(built)
+
+# Header N reflects the 254 enrolled subjects, not the 200 AE records
+tplyr_header_n(built)
+
+# Restrict the population to the safety set
+saf <- pop_data(cols = c("TRTA" = "TRT01P"), where = SAFFL == "Y")
+saf
+
+}

--- a/man/replace_leading_whitespace.Rd
+++ b/man/replace_leading_whitespace.Rd
@@ -17,3 +17,13 @@ Character vector with leading spaces replaced
 \description{
 Useful for HTML rendering where leading spaces are collapsed.
 }
+\examples{
+# Indentation survives an HTML renderer that would collapse plain spaces
+terms <- c("CARDIAC DISORDERS", "   ATRIAL FIBRILLATION")
+out <- replace_leading_whitespace(terms)
+out
+
+# One replacement per leading space; interior spacing is untouched
+replace_leading_whitespace("  A B", replace_with = "-")
+
+}

--- a/man/str_extract_num.Rd
+++ b/man/str_extract_num.Rd
@@ -17,3 +17,21 @@ Numeric vector
 \description{
 Extracts the Nth numeric value from a formatted tplyr2 string.
 }
+\examples{
+cells <- c(" 22 (25.6\%)", "  9 (10.5\%)", " 55 (64.0\%)")
+
+# Default pulls the count; index = 2 pulls the percent
+str_extract_num(cells)
+str_extract_num(cells, index = 2)
+
+# Asking past the available numbers gives NA, as does an NA input
+str_extract_num(c(" 5", NA), index = 2)
+
+# Recover a sort key from an already-formatted table
+built <- tplyr_build(
+  tplyr_spec(cols = "TRT01P", layers = tplyr_layers(group_count("AGEGR1"))),
+  tplyr_adsl
+)
+built[order(-str_extract_num(built$res1)), c("rowlabel1", "res1")]
+
+}

--- a/man/total_group.Rd
+++ b/man/total_group.Rd
@@ -18,3 +18,21 @@ A tplyr_total_group object
 Specifies that a synthetic "Total" column level should be added by
 duplicating all rows with the specified column variable set to the label.
 }
+\examples{
+# Adds a "Total" column spanning every arm, alongside the individual arms
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  total_groups = list(total_group("TRT01P")),
+  layers = tplyr_layers(group_count("AGEGR1"))
+)
+tplyr_build(spec, tplyr_adsl)
+
+# Rename the total column
+all_pts <- tplyr_spec(
+  cols = "TRT01P",
+  total_groups = list(total_group("TRT01P", label = "All Patients")),
+  layers = tplyr_layers(group_count("SEX"))
+)
+tplyr_build(all_pts, tplyr_adsl)
+
+}

--- a/man/tplyr2-package.Rd
+++ b/man/tplyr2-package.Rd
@@ -8,6 +8,15 @@
 \description{
 Implements a grammar of summary data for clinical reports. Clinical summary tables are decomposed into modular layers, each representing an independent summary block. Supports count, descriptive statistics, and shift layer types with a declarative spec-based API built on data.table for performance.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/atorus-research/tplyr2}
+  \item \url{https://atorus-research.github.io/tplyr2/}
+  \item Report bugs at \url{https://github.com/atorus-research/tplyr2/issues}
+}
+
+}
 \author{
 \strong{Maintainer}: Mike Stackhouse \email{mike.stackhouse@atorusresearch.com}
 

--- a/man/tplyr2_options.Rd
+++ b/man/tplyr2_options.Rd
@@ -33,4 +33,28 @@ summary functions. Default: \code{NULL}.}
 \item{tplyr2.scipen}{Integer. scipen value used during \code{tplyr_build()}
 to prevent scientific notation. Default: \code{9999}.}
 }
+
+An unrecognized option name is an error rather than a silent no-op, so a
+misspelling cannot quietly leave the build on the default behavior.
+}
+\examples{
+# Inspect the current values
+tplyr2_options()
+
+# Setting returns the previous values, so the change can be undone
+old <- tplyr2_options(IBMRounding = TRUE)
+getOption("tplyr2.IBMRounding")
+do.call(options, old)
+getOption("tplyr2.IBMRounding")
+
+# IBM (half-away-from-zero) rounding vs R's banker's rounding
+fmt <- f_str("xx", "n")
+apply_formats(fmt, n = 2.5)
+old <- tplyr2_options(IBMRounding = TRUE)
+apply_formats(fmt, n = 2.5)
+do.call(options, old)
+
+# A misspelled name errors instead of setting a dead option
+try(tplyr2_options(IBMrounding = TRUE))
+
 }

--- a/man/tplyr_build.Rd
+++ b/man/tplyr_build.Rd
@@ -17,7 +17,11 @@ tplyr_build(spec, data, pop_data = NULL, metadata = FALSE, ...)
 back to source data rows via \code{tplyr_meta_result()} and
 \code{tplyr_meta_subset()}.}
 
-\item{...}{Additional named arguments to override spec-level parameters}
+\item{...}{Additional named arguments overriding spec-level parameters. Names
+must match a field of \code{spec} (or \code{where}/\code{pop_data}); an unrecognized name
+is an error rather than a silent no-op. Because \code{...} is evaluated eagerly,
+a \code{where} override must be a character string or a quoted expression, not
+the bare expression \code{\link[=tplyr_spec]{tplyr_spec()}} accepts.}
 }
 \value{
 A data.frame with rowlabel, res, and ord columns
@@ -25,4 +29,33 @@ A data.frame with rowlabel, res, and ord columns
 \description{
 Executes the table specification against the provided data, producing
 a formatted output data frame.
+}
+\examples{
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(group_count("AGEGR1"))
+)
+tplyr_build(spec, tplyr_adsl)
+
+# Override spec fields at build time without editing the spec. Overrides go
+# through `...`, which evaluates eagerly, so a `where` must be a string or
+# quoted -- not the bare expression tplyr_spec() accepts.
+tplyr_build(spec, tplyr_adsl, where = "SEX == 'F'")
+tplyr_build(spec, tplyr_adsl, where = quote(SEX == "F"))
+
+# Population data supplies the denominators and the header N
+pop_spec <- tplyr_spec(
+  cols = "TRTA",
+  pop_data = pop_data(cols = c("TRTA" = "TRT01P")),
+  layers = tplyr_layers(
+    group_count("AEBODSYS",
+                settings = layer_settings(distinct_by = "USUBJID"))
+  )
+)
+head(tplyr_build(pop_spec, tplyr_adae, pop_data = tplyr_adsl))
+
+}
+\seealso{
+\code{\link[=tplyr_spec]{tplyr_spec()}} to build the specification, and
+\code{\link[=tplyr_numeric_data]{tplyr_numeric_data()}} for the unformatted values behind the cells.
 }

--- a/man/tplyr_from_ard.Rd
+++ b/man/tplyr_from_ard.Rd
@@ -18,3 +18,31 @@ A data.frame with the same structure as \code{tplyr_build()} output
 Takes Analysis Results Data (long format) and a \code{tplyr_spec}, then
 applies the spec's formatting rules to produce a formatted output table.
 }
+\examples{
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(group_desc("AGE"))
+)
+built <- tplyr_build(spec, tplyr_adsl)
+
+# Round-tripping through the ARD reproduces the formatted cells, so a table
+# can be rebuilt from stored results without the subject-level data
+ard <- tplyr_to_ard(built)
+recon <- tplyr_from_ard(ard, spec)
+recon[, c("rowlabel1", "res1")]
+identical(as.vector(recon$res1), as.vector(built$res1))
+
+# Changing only the spec's formats re-renders the same numbers differently
+respec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(
+    group_desc("AGE", settings = layer_settings(
+      format_strings = list("Mean (SD)" = f_str("xx.xx (xx.xxx)", "mean", "sd"))))
+  )
+)
+tplyr_from_ard(ard, respec)[, c("rowlabel1", "res1")]
+
+}
+\seealso{
+\code{\link[=tplyr_to_ard]{tplyr_to_ard()}} to produce the ARD.
+}

--- a/man/tplyr_header_n.Rd
+++ b/man/tplyr_header_n.Rd
@@ -17,3 +17,20 @@ or NULL if no population data was used.
 Returns the population-based header N values that were computed during
 \code{tplyr_build()}. Only available when population data was provided.
 }
+\examples{
+spec <- tplyr_spec(
+  cols = "TRTA",
+  pop_data = pop_data(cols = c("TRTA" = "TRT01P")),
+  layers = tplyr_layers(group_count("AEBODSYS"))
+)
+built <- tplyr_build(spec, tplyr_adae, pop_data = tplyr_adsl)
+tplyr_header_n(built)
+
+# NULL when the build had no population data to draw an N from
+no_pop <- tplyr_build(
+  tplyr_spec(cols = "TRT01P", layers = tplyr_layers(group_count("SEX"))),
+  tplyr_adsl
+)
+tplyr_header_n(no_pop)
+
+}

--- a/man/tplyr_layers.Rd
+++ b/man/tplyr_layers.Rd
@@ -16,3 +16,16 @@ A list of tplyr_layer objects
 \description{
 Wraps one or more layer objects into a validated list for use in tplyr_spec().
 }
+\examples{
+# Layers stack in the order given, and may mix types freely
+layers <- tplyr_layers(
+  group_desc("AGE"),
+  group_count("SEX"),
+  group_count("AGEGR1")
+)
+length(layers)
+
+spec <- tplyr_spec(cols = "TRT01P", layers = layers)
+tplyr_build(spec, tplyr_adsl)
+
+}

--- a/man/tplyr_meta.Rd
+++ b/man/tplyr_meta.Rd
@@ -35,3 +35,19 @@ Contains filter expressions that, when evaluated against the original data,
 reproduce the subset of rows that contributed to a specific cell in the
 output table.
 }
+\examples{
+# Usually obtained from a build rather than constructed by hand
+m <- tplyr_meta(
+  names = c("TRT01P", "AGEGR1"),
+  filters = list(quote(TRT01P == "Placebo"), quote(AGEGR1 == "65-80")),
+  layer_index = 1L
+)
+m
+
+# The filters are ordinary language objects, so they can be applied directly
+subset(tplyr_adsl, TRT01P == "Placebo" & AGEGR1 == "65-80")[1:3, c("USUBJID", "AGEGR1")]
+
+}
+\seealso{
+\code{\link[=tplyr_meta_result]{tplyr_meta_result()}} to retrieve one from a build.
+}

--- a/man/tplyr_meta_result.Rd
+++ b/man/tplyr_meta_result.Rd
@@ -22,3 +22,18 @@ A \code{tplyr_meta} object, or NULL if no metadata for that cell
 Returns a \code{tplyr_meta} object containing the filter expressions
 that describe the source data for the specified cell.
 }
+\examples{
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(group_count("AGEGR1"))
+)
+built <- tplyr_build(spec, tplyr_adsl, metadata = TRUE)
+built[, c("row_id", "rowlabel1", "res1")]
+
+# The filters behind the Placebo / 65-80 cell
+tplyr_meta_result(built, built$row_id[1], "res1")
+
+}
+\seealso{
+\code{\link[=tplyr_meta_subset]{tplyr_meta_subset()}} to fetch the source rows themselves.
+}

--- a/man/tplyr_meta_subset.Rd
+++ b/man/tplyr_meta_subset.Rd
@@ -26,3 +26,20 @@ A data.frame subset of the original data, or NULL if no metadata
 Evaluates the stored filter expressions against the original data to return
 the rows that contributed to the specified output cell.
 }
+\examples{
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(group_count("AGEGR1"))
+)
+built <- tplyr_build(spec, tplyr_adsl, metadata = TRUE)
+built[, c("row_id", "rowlabel1", "res1")]
+
+# Trace the first cell back to the subjects it counted
+src <- tplyr_meta_subset(built, built$row_id[1], "res1", tplyr_adsl)
+nrow(src)
+head(src[, c("USUBJID", "TRT01P", "AGEGR1")])
+
+# The row count matches the number displayed in the cell
+built$res1[1]
+
+}

--- a/man/tplyr_numeric_data.Rd
+++ b/man/tplyr_numeric_data.Rd
@@ -20,3 +20,27 @@ index. Returns NULL if numeric data was not retained.
 Returns the unformatted numeric data that was computed during the build
 process, before formatting and pivoting to wide format.
 }
+\examples{
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(
+    group_count("AGEGR1"),
+    group_desc("AGE")
+  )
+)
+built <- tplyr_build(spec, tplyr_adsl)
+
+# One data.frame per layer, keyed by layer index
+names(tplyr_numeric_data(built))
+
+# The counts behind the formatted cells, before rounding and padding
+head(tplyr_numeric_data(built, 1))
+
+# Every statistic the desc layer computed, including unused ones
+names(tplyr_numeric_data(built, 2))
+
+}
+\seealso{
+\code{\link[=tplyr_stats_data]{tplyr_stats_data()}} for a single statistic with its grouping
+columns.
+}

--- a/man/tplyr_read_spec.Rd
+++ b/man/tplyr_read_spec.Rd
@@ -16,3 +16,27 @@ A tplyr_spec object
 Deserializes a spec from a file. Expressions are reconstructed from their
 string representations.
 }
+\examples{
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  where = SAFFL == "Y",
+  layers = tplyr_layers(group_count("AGEGR1", by = "SEX"))
+)
+
+path <- file.path(tempdir(), "spec.json")
+tplyr_write_spec(spec, path)
+
+# The round trip reproduces the spec, and the same table
+spec2 <- tplyr_read_spec(path)
+spec2
+identical(tplyr_build(spec, tplyr_adsl), tplyr_build(spec2, tplyr_adsl))
+
+# tplyr_build() also accepts a spec file path directly
+head(tplyr_build(path, tplyr_adsl))
+
+unlink(path)
+
+}
+\seealso{
+\code{\link[=tplyr_write_spec]{tplyr_write_spec()}} to write one.
+}

--- a/man/tplyr_spec.Rd
+++ b/man/tplyr_spec.Rd
@@ -36,3 +36,29 @@ A tplyr_spec object
 The spec is a pure configuration object describing what to compute.
 No data processing occurs until \code{tplyr_build()} is called.
 }
+\examples{
+# A spec is inert configuration -- nothing is computed until tplyr_build()
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(
+    group_count("AGEGR1"),
+    group_desc("AGE")
+  )
+)
+spec
+
+tplyr_build(spec, tplyr_adsl)
+
+# A global `where` filter applies to every layer
+safety <- tplyr_spec(
+  cols = "TRT01P",
+  where = SAFFL == "Y",
+  layers = tplyr_layers(group_count("SEX"))
+)
+tplyr_build(safety, tplyr_adsl)
+
+}
+\seealso{
+\code{\link[=tplyr_build]{tplyr_build()}} to execute a spec, \code{\link[=tplyr_layers]{tplyr_layers()}} to assemble
+layers, and \code{\link[=layer_settings]{layer_settings()}} for per-layer configuration.
+}

--- a/man/tplyr_to_ard.Rd
+++ b/man/tplyr_to_ard.Rd
@@ -23,3 +23,24 @@ Transforms the numeric data attached to a \code{tplyr_build()} result into
 a long-format data frame with one row per statistic per group combination.
 This is compatible with the CDISC Analysis Results Data standard.
 }
+\examples{
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  layers = tplyr_layers(
+    group_count("AGEGR1"),
+    group_desc("AGE")
+  )
+)
+built <- tplyr_build(spec, tplyr_adsl)
+
+ard <- tplyr_to_ard(built)
+head(ard)
+
+# One row per statistic per group; analysis_id identifies the layer
+table(ard$analysis_id)
+unique(ard$stat_name[ard$analysis_id == 2])
+
+}
+\seealso{
+\code{\link[=tplyr_from_ard]{tplyr_from_ard()}} to rebuild a formatted table from an ARD.
+}

--- a/man/tplyr_write_spec.Rd
+++ b/man/tplyr_write_spec.Rd
@@ -23,3 +23,31 @@ Expressions (e.g., \code{where} clauses) are deparsed to strings and
 reconstructed on read. Format string objects (\code{f_str}) are stored as
 their component parts and regenerated on read.
 }
+\examples{
+spec <- tplyr_spec(
+  cols = "TRT01P",
+  where = SAFFL == "Y",
+  layers = tplyr_layers(
+    group_count("AGEGR1", by = "SEX", settings = layer_settings(
+      denoms_by = c("TRT01P", "SEX"),
+      format_strings = list(n_counts = f_str("xx (xx.x\%)", "n", "pct"))))
+  )
+)
+
+path <- file.path(tempdir(), "spec.json")
+tplyr_write_spec(spec, path)
+cat(readLines(path), sep = "\n")
+
+# YAML is chosen by the file extension
+if (requireNamespace("yaml", quietly = TRUE)) {
+  ypath <- file.path(tempdir(), "spec.yaml")
+  tplyr_write_spec(spec, ypath)
+  cat(readLines(ypath), sep = "\n")
+  unlink(ypath)
+}
+unlink(path)
+
+}
+\seealso{
+\code{\link[=tplyr_read_spec]{tplyr_read_spec()}} to read one back.
+}


### PR DESCRIPTION
Prepares tplyr2 0.2.0 for a **first** CRAN submission. tplyr2 is not currently on CRAN; the predecessor `Tplyr` 1.3.3 is.

`R CMD check --as-cran`: **0 errors, 0 warnings, 0 notes**. Test suite: 2528 passing. All 20 vignettes build.

## The substantive change: examples on every export

**39 of 39 exported objects now have executable examples, up from 7.**

Missing examples is the most common reason a first CRAN submission gets rejected — CRAN policy asks for them so exported code is automatically tested. The trap is that **`R CMD check` does not flag it**: the check was already returning a clean 0/0/0 with 32 exports having no example at all, including the entire core API (`tplyr_spec`, `tplyr_build`, `group_count`, `group_desc`, `group_shift`, `f_str`, `layer_settings`).

The examples use the bundled `tplyr_adsl`/`tplyr_adae`/`tplyr_adlb` data, write only to `tempdir()`, and restore any options they change. None exceeds the 5s-per-example threshold; total check time is unchanged at ~52s.

Rather than token one-liners they demonstrate what people actually get wrong: `denoms_by` changing the percentage base, auto-precision with `precision_cap`, the two `group_analyze()` return modes, `f_str()`'s `empty` vs `.overall` semantics, and a metadata round-trip from a rendered cell back to the source subjects that produced it.

## Two documentation errors, found by writing the examples

Both were cases where an example written from the documentation failed:

- **`apply_formats()`** documented `fmt` as accepting "an f_str object **or character format string**". The code rejects a bare string outright — the variable names are what bind `...` to the format groups. Documentation corrected to match.
- **`tplyr_build()`'s `...`** did not mention that overrides are evaluated eagerly. `where = SEX == "F"` fails, even though `tplyr_spec()` accepts that exact bare expression; an override must be a string or `quote()`d. That asymmetry is a real trap and is now documented, along with the fact that unknown override names error.

## CRAN scaffolding

- `cran-comments.md` recording test environments and pre-answering the question a reviewer will certainly ask: why a package named `tplyr2` alongside the existing `Tplyr`.
- `URL` and `BugReports` added to DESCRIPTION.
- `_pkgdown.yml` pointed at the live site. It referenced `github.com/mstackhouse/tplyr2`, a personal-fork URL, rather than `atorus-research.github.io/tplyr2`.

## NEWS reframing

The changelog opened with a "Breaking changes" section describing changes relative to 0.1.0 — a version that was never public. For a reviewer meeting tplyr2 for the first time, "breaking" relative to nothing is confusing. Added a preamble stating this is the first CRAN release, summarizing the package, and explaining the relationship to `Tplyr`; scoped the breaking-changes heading to 0.1.0 so the detail stays useful to anyone who installed from GitHub.

## Still required before submitting

- **Cross-platform verification.** `check_win_devel()` and rhub run on CRAN's own infrastructure, with compilers and locales that local macOS and GitHub Actions don't cover. Running now; results should be clean before the submission is spent.
- **The submission itself is the maintainer's.** `devtools::submit_cran()` uploads the tarball, but CRAN then emails a confirmation link to the maintainer address that must be clicked or the submission is discarded.
- **No tag cut.** Worth tagging `v0.2.0` once this merges and the cross-platform checks are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)